### PR TITLE
Add document status to header

### DIFF
--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -4,11 +4,13 @@
 		<meta charset="utf-8" />
 		<title>eBraille Tagging Best Practices</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="../../common/js/status.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
 				shortName: 'ebraille-tag',
 				specStatus: 'base',
+				daisyStatus: 'ED',
 				latestVersion: 'https://daisy.github.io/ebraille/best-practices/tagging',
 				edDraftURI: null,
 				editors: [
@@ -27,7 +29,8 @@
 						url: 'https://daisy.org'
 					}
 				],
-				github: 'daisy/ebraille'
+				github: 'daisy/ebraille',
+				postProcess: [addDAISYStatus]
 			};
 			// ]]>
 		</script>

--- a/common/js/status.js
+++ b/common/js/status.js
@@ -1,0 +1,30 @@
+
+function addDAISYStatus() {
+
+	if (!respecConfig.hasOwnProperty('daisyStatus')) {
+		console.log('daisyStatus property not set. No status will be added.')
+		return;
+	}
+	
+	const status = {
+		'ed': 'Editor\'s Draft',
+		'wd': 'Working Draft',
+		'cr': 'Candidate Recommendation',
+		'pr': 'Proposed Recommendation',
+		'rec': 'Recommendation'
+	};
+	
+	var daisyStatus = respecConfig.daisyStatus.toLowerCase();
+	
+	if (!status.hasOwnProperty(daisyStatus)) {
+		console.log('Unknown status "' + daisyStatus + '" set. No status will be added.');
+		return;
+	}
+	
+	var statusSpan = document.createElement('span');
+		statusSpan.id = 'daisy-status';
+		statusSpan.appendChild(document.createTextNode('DAISY ' + status[daisyStatus]));
+	
+	document.getElementById('w3c-state').insertAdjacentElement('afterBegin', statusSpan);
+
+}

--- a/index.html
+++ b/index.html
@@ -4,11 +4,13 @@
 		<meta charset="utf-8" />
 		<title>eBraille 1.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
+		<script src="common/js/status.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
 				shortName: 'ebraille',
 				specStatus: 'base',
+				daisyStatus: 'ED',
 				latestVersion: 'https://daisy.github.io/ebraille/',
 				edDraftURI: null,
 				editors: [
@@ -52,7 +54,8 @@
 						url: 'https://daisy.org'
 					}
 				],
-				github: 'daisy/ebraille'
+				github: 'daisy/ebraille',
+				postProcess: [addDAISYStatus]
 			};
 			// ]]>
 		</script>


### PR DESCRIPTION
Because we're using the respec base profile to add DAISY's branding, we don't have access to use the built-in specification status identifiers (plus these are W3C-specific).

This pull request adds a new property called "daisyStatus" to the respec metadata to identify the status. For now, I've matched the respec pattern of it having the values "ED" for editor's draft and "WD" for working draft. (There are also "CR", "PR", and "REC" placeholder codes, but we can figure out if we need some or all of these for DAISY process later.)

When you add these codes, there's a post-processing script that will add the corresponding status designator to the header before the publication date.

The preview for the specification should provide an example of the functionality (assuming scripting works with it), so I won't add an additional preview for the tagging document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/152.html" title="Last updated on Feb 27, 2024, 1:28 PM UTC (54904bd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/152/056251f...54904bd.html" title="Last updated on Feb 27, 2024, 1:28 PM UTC (54904bd)">Diff</a>