### PR TITLE
Add overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,12 +73,7 @@
 	<body>
 		<p class="copyright">Copyright &#169; DAISY Consortium 2023</p>
 		<section id="abstract">
-			<p>The specification defines eBraille, a digital reading format for braille publications. Unlike braille
-				formats that focus on interchanging embosser-ready braille, eBraille focuses on adapting braille for
-				reading in refreshable braille displays with different line lengths.</p>
-			<p>The eBraille format is built on an EPUB 3-compatible file set. Unlike EPUB 3, however, it is designed to
-				be flexible for deployment. An eBraille publication is easy to deploy on the web, unzip on a user's
-				local file system, or distribute in EPUB 3-compatible packaging.</p>
+			<p>This specification defines eBraille, a digital reading format for braille publications.</p>
 		</section>
 		<section id="sotd">
 			<div data-include="common/status.html" data-include-replace="true"></div>
@@ -88,6 +83,31 @@
 		</section>
 		<section id="intro">
 			<h2>Introduction</h2>
+
+			<section id="overview">
+				<h3>Overview</h3>
+
+				<p>Unlike braille formats that focus on interchanging embosser-ready braille, eBraille focuses on
+					adapting braille for reading in refreshable braille displays with different line lengths.</p>
+
+				<p>In order to maintain close alignment with mainstream publishing formats, and simplify transcription
+					of these works, the eBraille format is built on an EPUB 3-compatible file set &#8212; it
+					incorporates XHTML documents, CSS, images, audio, and video. This means that an [=ebraille
+					publication=] shares its technology with the web, making it compatible for reading in standard web
+					browsers.</p>
+
+				<p>An [=eBraille publication=] differs from reading a typical web site in that the braille is not
+					transformed on the fly but comes formatted according to the rules of the regional braille code where
+					the publication was produced. But users are not locked into the default display. With with the
+					display flexibility of CSS, and standardized markup practices, they could apply styles for another
+					region or even modify the display to their own preferences (e.g., by changing the maximum line
+					length).</p>
+
+				<p>eBraille publications are also designed to be flexible for deployment. An eBraille publication can be
+					placed on the web, unzipped on a user's local file system, or distributed in EPUB 3-compatible
+					packaging. And as web-compatible file sets, they are adaptable to future changes to publishing
+					formats.</p>
+			</section>
 
 			<section id="conformance"></section>
 
@@ -159,7 +179,7 @@
 
 				<p>The primary difference between the eBraille format and EPUB 3 is eBraille publications do not have to
 					be packaged and distributed in an [=EPUB container=] [[epub-33]]. An [=eBraille publication=] will
-					be easy to package in an EPUB container if desired, however.</p>
+					be easy to package in an EPUB container when needed, however.</p>
 			</section>
 		</section>
 		<section id="ebrl-resources">

--- a/index.html
+++ b/index.html
@@ -98,10 +98,9 @@
 
 				<p>An [=eBraille publication=] differs from reading a typical web site in that the braille is not
 					transformed on the fly but comes formatted according to the rules of the regional braille code where
-					the publication was produced. But users are not locked into the default display. With with the
-					display flexibility of CSS, and standardized markup practices, they could apply styles for another
-					region or even modify the display to their own preferences (e.g., by changing the maximum line
-					length).</p>
+					the publication was produced. But users are not locked into the default display. With the display
+					flexibility of CSS, and standardized markup practices, they could apply styles for another region or
+					even modify the display to their own preferences (e.g., by changing the maximum line length).</p>
 
 				<p>eBraille publications are also designed to be flexible for deployment. An eBraille publication can be
 					placed on the web, unzipped on a user's local file system, or distributed in EPUB 3-compatible


### PR DESCRIPTION
I was going to make a tweak to the abstract, but I noticed we don't have a proper overview for the document. I took the second paragraph from the abstract and added some more text to it to create one. Suggestions on how it can be improved are welcome.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/intro-edits/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/intro-edits/index.html)
