### PR TITLE
Add future directions section

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,10 +193,10 @@
 					features:</p>
 
 				<ul>
-					<li>scripting &#8212; the use of JavaScript in eBraille content documents is currently prohibited.
-						The working group is seeking further input on the need for dynamic braille before allowing
-						scripting as the ability to script documents increases the security and privacy risks of the
-						format.</li>
+					<li>scripting &#8212; the use of JavaScript in [=eBraille content documents=] is currently
+						prohibited. The working group is seeking further input on the need for dynamic braille before
+						allowing scripting as the ability to script documents increases the security and privacy risks
+						of the format.</li>
 					<li>CSS extensions &#8212; the first version of eBraille uses standard CSS properties to format
 						braille content. There may be a need to extend CSS in the future to handle more complex
 						formatting cases, which will also require defining reading system implementations.</li>

--- a/index.html
+++ b/index.html
@@ -180,6 +180,28 @@
 					be packaged and distributed in an [=EPUB container=] [[epub-33]]. An [=eBraille publication=] will
 					be easy to package in an EPUB container when needed, however.</p>
 			</section>
+
+			<section id="future-dir" class="informative">
+				<h3>Future directions</h3>
+
+				<p>The first version of the eBraille format is focused on creating a reading experience that is
+					minimally feature complete for the majority of braille publications. It is not expected that this
+					version will handle every unique formatting requirement of every publication type, but future drafts
+					and versions of this specification will focus on making the format more feature complete.</p>
+
+				<p>In particular, the working group will expects to review the current support decisions for the
+					following features:</p>
+
+				<ul>
+					<li>scripting &#8212; the use of JavaScript in eBraille content documents is currently prohibited.
+						The working group is seeking further input on the need for dynamic braille before allowing
+						scripting as the ability to script documents increases the security and privacy risks of the
+						format.</li>
+					<li>CSS extensions &#8212; the first version of eBraille uses standard CSS properties to format
+						braille content. There may be a need to extend CSS in the future to handle more complex
+						formatting cases, which will also require defining reading system implementations.</li>
+				</ul>
+			</section>
 		</section>
 		<section id="ebrl-resources">
 			<h2>Publication resources</h2>

--- a/index.html
+++ b/index.html
@@ -189,8 +189,8 @@
 					version will handle every unique formatting requirement of every publication type, but future drafts
 					and versions of this specification will focus on making the format more feature complete.</p>
 
-				<p>In particular, the working group will expects to review the current support decisions for the
-					following features:</p>
+				<p>In particular, the working group expects to review the current support decisions for the following
+					features:</p>
 
 				<ul>
 					<li>scripting &#8212; the use of JavaScript in eBraille content documents is currently prohibited.


### PR DESCRIPTION
Here's a start on the new section. Let me know if this makes sense and if there are any improvements or additions that can be made to it.

* [Preview](https://raw.githack.com/daisy/ebraille/add/future-directions/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/add/future-directions/index.html)
