### PR TITLE
Add restriction on declaring fixed layout properties

### DIFF
--- a/index.html
+++ b/index.html
@@ -479,6 +479,21 @@
 				</div>
 			</section>
 		</section>
+		<section id="ebrl-rendering-control">
+			<h2>Layout rendering control</h2>
+
+			<p>eBraille does not support <a data-cite="epub-33#sec-fixed-layouts">fixed layouts</a> as defined in
+				[[epub-33]]. Consequently, [=eBraille publications=]:</p>
+
+			<ul>
+				<li>MUST NOT specify the <a data-cite="epub-33#layout"><code>rendition:layout</code> property</a> with
+					the value <code>pre-paginated</code> in the package document metadata or specify its override
+					property <code>rendition:layout-pre-paginated</code> on <a href="#spine">spine</a> items
+					[[epub-33]].</li>
+				<li>MUST NOT specify any other properties or spine overrides defined in <a
+						data-cite="epub-33#sec-fxl-package">Fixed-layout package settings</a> [[epub-33]].</li>
+			</ul>
+		</section>
 		<section id="ebrl-nav">
 			<h2>Primary entry page</h2>
 


### PR DESCRIPTION
This pull request explicitly bans the fixed layout properties from being specified. I was going to blanket ban all of them, since the default layout is always reflowable, but there may be some good reason why someone wants to explicitly declare their publication is reflowable.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/no-fxl/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/no-fxl/index.html)
