### PR TITLE
Add ebraille reading system section

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,18 +763,18 @@
 						>requirements for EPUB reading systems</a> [[epub-rs-33]], with the following differences:</p>
 
 				<ul>
-					<li>If it supports web access, the reading system SHOULD allow users to download unpackaged
-						[=eBraille publications=] hosted on the web by specifying the path to the package document.</li>
-					<li>It MUST support PDF for tactile graphics.</li>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-epub-rs-conf-remote-res">remote resources</a>
 						[[epub-rs-33]].</li>
-					<li>As remote resources, forms, and scripting are not supported, it MUST NOT allow eBraille
-						publications to have <a data-cite="epub-rs-33#sec-epub-rs-network-access">network access</a>
+					<li>As remote resources, forms, and scripting are not supported, it MUST NOT allow [=eBraille
+						publications=] to have <a data-cite="epub-rs-33#sec-epub-rs-network-access">network access</a>
 						[[epub-rs-33]]. (Note that barring network access should not prevent users from following <a
 							data-cite="epub-rs-33#sec-epub-rs-external-links">external hyperlinks</a> [[epub-rs-33]] in
 						a publication.)</li>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-pkg-doc-manifest">manifest fallbacks</a>
 						[[epub-rs-33]].</li>
+					<li>It MUST only support [=eBraille content documents=] in the <code>spine</code>. The reading
+						system MAY reject eBraille publications with other formats in the spine or ignore their entries
+						when rendering the publication.</li>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-xhtml-forms">form submission</a>
 						[[epub-rs-33]].</li>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-svg">SVG content documents</a>. (Note that this
@@ -789,10 +789,18 @@
 						version.</li>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#epub-rs-33/#sec-rendering-control">fixed
 							layouts</a> [[epub-rs-33]].</li>
-					<li>It does not have to support <a data-cite="epub-rs-33#sec-epub-rs-conf-backward">backward
+					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-epub-rs-conf-backward">backward
 							compatibility</a> or <a data-cite="epub-rs-33#sec-epub-rs-conf-forward">forward
 							compatibility</a> with other EPUB versions [[epub-rs-33]].</li>
 				</ul>
+
+				<p>In addition, eBraille reading systems MUST support PDF for tactile graphics. If an eBraille reading
+					system is not capable of rendering PDFs embedded in [=eBraille content documents=], it MUST provide
+					a mechanism that allows the user to open the graphics in an application that supports PDF
+					rendering.</p>
+
+				<p>If an eBraille reading system supports web access, it SHOULD allow users to download unpackaged
+					eBraille publications hosted on the web by specifying the path to the package document.</p>
 			</section>
 
 			<section id="rs-browser">
@@ -807,7 +815,7 @@
 						eBraille reading system</a>.</p>
 
 				<p>Browser-based reading systems will be inherently less secure than dedicated eBraille reading systems,
-					as it will not likely be possible to disable features such as scripting, forms, and remote resources
+					as it will not likely be possible to disable features such as scripting, forms, and remote resource
 					access. Consequently, a browser-based reading system SHOULD follow all the <a
 						data-cite="epub-rs-33#sec-security-privacy">recommendations for securing publications</a>
 					defined in [[epub-rs-33]].</p>

--- a/index.html
+++ b/index.html
@@ -333,8 +333,6 @@
 
 				<p>For this reason, the eBraille file set MUST NOT include file references that use path-absolute-URL
 					strings.</p>
-
-				<p>Similarly, [=eBraille reading systems=] MUST NOT resolve path-absolute-URL strings.</p>
 			</section>
 		</section>
 		<section id="ebrl-package-doc">
@@ -499,9 +497,6 @@
 					<p>eBraille does not support scripted interactivity or form submissions. Consequently, authors MUST
 						NOT include [[html]] [^script^] elements or the [^form^] element's [^form/action^] attribute in
 							<a>eBraille content documents</a>.</p>
-
-					<p>[=Reading systems=] MUST NOT process [^script^] elements or allow the submission of [^form^]
-						elements.</p>
 
 					<div class="note">
 						<p>The lack of support for scripting means that html elements that depend on scripting (e.g.,
@@ -765,6 +760,7 @@
 				<ul>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-epub-rs-conf-remote-res">remote resources</a>
 						[[epub-rs-33]].</li>
+					<li>It MUST NOT resolve [=path-absolute-URL strings=] [[url]].</li>
 					<li>As remote resources, forms, and scripting are not supported, it MUST NOT allow [=eBraille
 						publications=] to have <a data-cite="epub-rs-33#sec-epub-rs-network-access">network access</a>
 						[[epub-rs-33]]. (Note that barring network access should not prevent users from following <a

--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
 
 				<p>[=eBraille content documents=] define the markup and presentation of the content of an [=eBraille
 					publication=]. An eBraille content document is encoded using <a data-cite="html#">XML syntax</a> of
-					[[html]], also commonly known as XHTML, and is styled using CSS [[css]].</p>
+					[[html]], also commonly known as XHTML, and is styled using CSS [[css2]].</p>
 
 				<p>eBraille content documents are not only formatted text. For example, they may include tactile
 					graphics, audio, and video. The primary difference between the features of an eBraille content
@@ -712,11 +712,11 @@
 			<h2>Accessibility</h2>
 
 			<p>[=eBraille publications=] fall under the category of <a data-cite="epub-a11y-11#sec-optimized-pubs"
-					>optimized publications</a> as defined by the <a data-cite="epub-a11y#">EPUB Accessibility
+					>optimized publications</a> as defined by the <a data-cite="epub-a11y-11#">EPUB Accessibility
 					specification</a> [[epub-a11y-11]]. eBraille publications are only meant for braille users, so it is
-				not expected that [=eBraille creators=] can produce them to fully meet the requirements of W3C's <a>Web
-					Content Accessibility Guidelines</a> [[wcag2]]. There is not always a benefit to braille users in
-				meeting all of that standards requirements.</p>
+				not expected that [=eBraille creators=] can produce them to fully meet the requirements of W3C's <a
+					data-cite="wcag#">Web Content Accessibility Guidelines</a> [[wcag22]]. There is not always a benefit
+				to braille users in meeting all of that standards requirements.</p>
 
 			<p>At the same time, it is possible to create eBraille publications that fail to meet the needs of users if
 				care is not taken to optimize the content. Not properly identifying headings, for example, will limit

--- a/index.html
+++ b/index.html
@@ -554,6 +554,85 @@
 				<p>Packaging requirements for eBraille publications will be added in a future update.</p>
 			</div>
 		</section>
+		<section id="ebrl-reading-systems">
+			<h2>eBraille Reading Systems</h2>
+
+			<section id="rs-intro" class="informative">
+				<h3>Introduction</h3>
+
+				<p>As an [=eBraille publication=] represents a subset of an <a data-cite="epub-33#sec-epub-conf">EPUB 3
+						publication</a> [[epub-33]], an eBraille reading system similarly consists of a subset of
+					features of a full <a data-cite="epub-rs-33#sec-rs-conformance">EPUB 3 reading system</a>
+					[[epub-rs-33]].</p>
+
+				<p>Similar to EPUB 3, eBraille does not define a uniform set of requirements that all reading systems
+					must meet. Support is instead based on the capabilities of the device. A reading system might not
+					support <a href="#ebrl-mo">media overlays</a>, for example, if it does not support audio
+					playback.</p>
+
+				<p>As eBraille publications can be deployed unpackaged on the web, users may not even always require a
+					dedicated eBraille reading system to read them. A very basic reading experience will be possible
+					directly from a standard web browser, and browser-based reading systems can provide a richer reading
+					experience for reading on the web.</p>
+			</section>
+
+			<section id="rs-req">
+				<h3>Reading system requirements</h3>
+
+				<p>An [=eBraille reading system=] MUST meet the <a data-cite="epub-rs-33#sec-rs-conformance"
+						>requirements for EPUB reading systems</a> [[epub-rs-33]], with the following differences:</p>
+
+				<ul>
+					<li>If it supports web access, the reading system SHOULD allow users to download unpackaged
+						[=eBraille publications=] hosted on the web by specifying the path to the package document.</li>
+					<li>It MUST support PDF for tactile graphics.</li>
+					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-epub-rs-conf-remote-res">remote resources</a>
+						[[epub-rs-33]].</li>
+					<li>As remote resources, forms, and scripting are not supported, it MUST NOT allow eBraille
+						publications to have <a data-cite="epub-rs-33#sec-epub-rs-network-access">network access</a>
+						[[epub-rs-33]]. (Note that barring network access should not prevent users from following <a
+							data-cite="epub-rs-33#sec-epub-rs-external-links">external hyperlinks</a> [[epub-rs-33]] in
+						a publication.)</li>
+					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-pkg-doc-manifest">manifest fallbacks</a>
+						[[epub-rs-33]].</li>
+					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-xhtml-forms">form submission</a>
+						[[epub-rs-33]].</li>
+					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-svg">SVG content documents</a>. (Note that this
+						does not affect <a data-cite="epub-rs-33#sec-xhtml-svg">embedded SVG</a> [[epub-rs-33]].)</li>
+					<li>It MUST NOT support EPUB 3's <a data-cite="epub-33#sec-css-prefixed">prefixed CSS properties</a>
+						[[epub-33]].</li>
+					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-scripted-content">scripting</a>
+						[[epub-rs-33]].</li>
+					<li>It is not required that eBraille publications be <a data-cite="epub-rs-33#sec-container-iri"
+							>assigned a unique URL</a> [[epub-rs-33]], as scripting is not supported, but it is still
+						recommended to domain isolate publications in case scripting is introduced in a future
+						version.</li>
+					<li>It MUST NOT support <a data-cite="epub-rs-33#epub-rs-33/#sec-rendering-control">fixed
+							layouts</a> [[epub-rs-33]].</li>
+					<li>It does not have to support <a data-cite="epub-rs-33#sec-epub-rs-conf-backward">backward
+							compatibility</a> or <a data-cite="epub-rs-33#sec-epub-rs-conf-forward">forward
+							compatibility</a> with other EPUB versions [[epub-rs-33]].</li>
+				</ul>
+			</section>
+
+			<section id="rs-browser">
+				<h3>Web-hosted eBraille publications</h3>
+
+				<p>[=eBraille publications=] made available over the web in unpackaged form are expected to provide
+					minimal functionality in web browsers without the need for a dedicated [=eBraille reading
+					system=].</p>
+
+				<p>If a browser-based reading system is created for reading unpackaged eBraille publications (e.g.,
+					through a web app), it SHOULD provide the same functionality as a <a href="#rs-req">dedicated
+						eBraille reading system</a>.</p>
+
+				<p>Browser-based reading systems will be inherently less secure than dedicated eBraille reading systems,
+					as it will not likely be possible to disable features such as scripting, forms, and remote resources
+					access. Consequently, a browser-based reading system SHOULD follow all the <a
+						data-cite="epub-rs-33#sec-security-privacy">recommendations for securing publications</a>
+					defined in [[epub-rs-33]].</p>
+			</section>
+		</section>
 		<div data-include="common/acknowledgements.html" data-include-replace="true"></div>
 	</body>
 </html>


### PR DESCRIPTION
Here's a first stab at reading system requirements. I went through the epub reading systems spec and listed out all the differences I could find in terms of support.

I'm less sure about the section on web-hosted publications, but leaving it in for now.

One question is do we want to mandate support for PDF for tactile images, should it be a recommendation, or do we need to mention it at all?

* [Preview](https://raw.githack.com/daisy/ebraille/spec/rs/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/rs/index.html)
