### PR TITLE
Add exemption for scripting in primary entry page

### DIFF
--- a/index.html
+++ b/index.html
@@ -605,8 +605,8 @@
 
 					<div class="note">
 						<p>An exemption is made to the scripting requirement for the <a href="#ebrl-nav">primary entry
-								page</a> so long as it is not listed in the spine. This exemption is only to allow
-							[=eBraille creators=] to add a user interface for web deployment.</p>
+								page</a> so long as it is not listed in the spine. The exemption is to allow publishers
+							to add a user interface for web deployment.</p>
 					</div>
 				</section>
 			</section>

--- a/index.html
+++ b/index.html
@@ -602,6 +602,12 @@
 							work in [=eBraille publications=]. It is strongly recommended not to include these elements,
 							as well.</p>
 					</div>
+
+					<div class="note">
+						<p>An exemption is made to the scripting requirement for the <a href="#ebrl-nav">primary entry
+								page</a> so long as it is not listed in the spine. This exemption is only to allow
+							[=eBraille creators=] to add a user interface for web deployment.</p>
+					</div>
 				</section>
 			</section>
 
@@ -692,6 +698,17 @@
 				<p>As the primary entry page is meant to help browser users navigate the publication, it SHOULD NOT be
 					included in the <a href="#spine">spine</a>. If the publication needs a table of contents in the
 					spine, it is better to create a separate document with publication-specific formatting.</p>
+
+				<p>The primary entry page MAY include [[html]] [^script^] elements only if the document is not included
+					in the spine. This exception is to allow publishers to include a user interface to better enable
+					reading of their publication in browsers. It is not meant for general scripting of the content.</p>
+
+				<div class="note">
+					<p>A scripted primary entry page is not allowed in the spine as an extra measure to ensure that the
+						scripting does not interfere with rendering in [=eBraille reading systems=]. Reading systems are
+						expected to disable the scripting in the primary entry page regardless of the document's
+						placement in the spine.</p>
+				</div>
 			</section>
 
 			<section id="navigation">


### PR DESCRIPTION
This will only allow script elements if the primary entry page is not listed in the spine, so not reachable by users in a dedicated ebraille reading system.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/pep-scripting/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/pep-scripting/index.html)
