### PR TITLE
Add section on multiple renditions

### DIFF
--- a/index.html
+++ b/index.html
@@ -363,6 +363,28 @@
 				<p>For this reason, the eBraille file set MUST NOT include file references that use path-absolute-URL
 					strings.</p>
 			</section>
+
+			<section id="multiple-renditions">
+				<h3>Multiple renditions</h3>
+
+				<p>An [=eBraille publication=] MAY contain multiple renditions of the content. The specifics of how this
+					is done are defined in EPUB 3 Multiple-Rendition Publications 1.1 [[epub-multi-rend-11]].</p>
+
+				<p>When including multiple renditions, only the <a data-cite="epub-multi-rend-11##container">default
+						rendition</a> [[epub-multi-rend-11]] (i.e., one listed first in the <a
+						data-cite="epub-33#sec-container-metainf-container.xml"><code>container.xml</code> file</a>
+					[[epub-33]]) is subject to the <a href="#fileset-structure">file naming and location
+						requirements</a> for the package document and primary entry page.</p>
+
+				<p>The default rendition MUST be a braille rendition (i.e., identified by a <a
+						data-cite="epub-multi-rend-11#accessMode-attr"><code>rendition:accessMode</code> attribute</a>
+					with the value "<code>tactile</code>" [[epub-multi-rend-11]]).</p>
+
+				<div class="note">
+					<p>[[epub-multi-rend-11]] is only a W3C Working Group Note. The technology is not currently
+						considered stable and should be used with appropriate caution.</p>
+				</div>
+			</section>
 		</section>
 		<section id="ebrl-package-doc">
 			<h2>Package Document</h2>


### PR DESCRIPTION
This new section exempts subsequent renditions from the file naming and location requirements. It also requires that the default rendition be tactile.

I've also added a note that the technology is not considered stable as, even though it's valid to use, it's not supported or been reviewed in the same way as epub 3 has.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/multi-rend/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/multi-rend/index.html)
