### PR TITLE
Add section on css support

### DIFF
--- a/index.html
+++ b/index.html
@@ -608,10 +608,15 @@
 			<section id="html-css">
 				<h3>CSS support</h3>
 
-				<div class="ednote">
-					<p>CSS properties that authors may use and reading systems must support will be added in a future
-						update.</p>
-				</div>
+				<p>The requirements for using CSS to style [=eBraille content documents=] are defined in <a
+						data-cite="epub-33#sec-css-req">CSS requirements</a> [[epub-33]] but with the following
+					differences:</p>
+
+				<ul>
+					<li>[=EPUB creators=] MUST NOT use <a data-cite="epub-33#css-prefixes"><code>-epub-</code> prefixed
+							properties</a> [[epub-33]].</li>
+					<li>CSS style sheets MUST be UTF-8 encoded [[unicode]].</li>
+				</ul>
 			</section>
 
 			<section id="authoring-bp" class="informative">

--- a/index.html
+++ b/index.html
@@ -617,6 +617,11 @@
 							properties</a> [[epub-33]].</li>
 					<li>CSS style sheets MUST be UTF-8 encoded [[unicode]].</li>
 				</ul>
+
+				<div class="note">
+					<p>More specific guidance on how to use CSS properties in eBraille content documents is provided in
+						the <a href="best-practices/styling/">eBraille Styling Best Practices</a>.</p>
+				</div>
 			</section>
 
 			<section id="authoring-bp" class="informative">

--- a/index.html
+++ b/index.html
@@ -613,8 +613,8 @@
 					differences:</p>
 
 				<ul>
-					<li>[=EPUB creators=] MUST NOT use <a data-cite="epub-33#css-prefixes"><code>-epub-</code> prefixed
-							properties</a> [[epub-33]].</li>
+					<li>[=eBraille creators=] MUST NOT use <a data-cite="epub-33#css-prefixes"><code>-epub-</code>
+							prefixed properties</a> [[epub-33]].</li>
 					<li>CSS style sheets MUST be UTF-8 encoded [[unicode]].</li>
 				</ul>
 


### PR DESCRIPTION
This is just a starter section to link us up with EPUB's requirements. I expect there will be additions to it later.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/css/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/css/index.html)
