### PR TITLE
Add additional daisy top matter

### DIFF
--- a/best-practices/styling/index.html
+++ b/best-practices/styling/index.html
@@ -14,7 +14,8 @@
 			var respecConfig = {
 				shortName: 'ebraille-style',
 				specStatus: 'base',
-				daisyStatus: 'ED',
+				daisyWG: 'eBraille Working Group',
+				daisyStatus: 'DRAFT-NOTE',
 				latestVersion: 'https://daisy.github.io/ebraille/best-practices/styling',
 				edDraftURI: null,
 				editors: [
@@ -143,6 +144,12 @@
 		<p class="copyright">Copyright &#169; DAISY Consortium 2024</p>
 		<section id="abstract">
 			<p>&#8230;</p>
+		</section>
+		<section id="sotd">
+			<div data-include="../../common/status.html" data-include-replace="true"></div>
+			<p>The eBraille Working Group is seeking input on all aspects of this document. It is particularly
+				interested in implementation experience both creating eBraille publication and creating reading systems
+				in which to read them.</p>
 		</section>
 		<section id="intro">
 			<h2>Introduction</h2>

--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -10,7 +10,8 @@
 			var respecConfig = {
 				shortName: 'ebraille-tag',
 				specStatus: 'base',
-				daisyStatus: 'ED',
+				daisyWG: 'eBraille Working Group',
+				daisyStatus: 'DRAFT-NOTE',
 				latestVersion: 'https://daisy.github.io/ebraille/best-practices/tagging',
 				edDraftURI: null,
 				editors: [
@@ -52,6 +53,12 @@
 		<p class="copyright">Copyright &#169; DAISY Consortium 2023</p>
 		<section id="abstract">
 			<p>&#8230;</p>
+		</section>
+		<section id="sotd">
+			<div data-include="../../common/status.html" data-include-replace="true"></div>
+			<p>The eBraille Working Group is seeking input on all aspects of this document. It is particularly
+				interested in implementation experience both creating eBraille publication and creating reading systems
+				in which to read them.</p>
 		</section>
 		<section id="intro">
 			<h2>Introduction</h2>

--- a/common/js/status.js
+++ b/common/js/status.js
@@ -15,7 +15,9 @@ function addDAISYStatus() {
 		'wd': 'Working Draft',
 		'cr': 'Candidate Recommendation',
 		'pr': 'Proposed Recommendation',
-		'rec': 'Recommendation'
+		'rec': 'Recommendation',
+		'draft-note': 'Draft Working Group Note',
+		'wg-note': 'Working Group Note'
 	};
 	
 	var daisyStatus = respecConfig.daisyStatus.toLowerCase();


### PR DESCRIPTION
This adds the status of this document section to both best practice guides. You can change these from the generic statement to something more specific if you want; you just have to delete the import div and write in a local statement.

It also adds a code for draft working group notes and the missing WG name to the respec metadata to make the top matter come out properly.

That should clear the lingering respec errors in the documents.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/188.html" title="Last updated on Jun 13, 2024, 7:17 PM UTC (057d887)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/188/c8bda06...057d887.html" title="Last updated on Jun 13, 2024, 7:17 PM UTC (057d887)">Diff</a>