### PR TITLE
Packaging and reading system requirements

### DIFF
--- a/index.html
+++ b/index.html
@@ -880,10 +880,6 @@
 								font used by the reading device, using absolute lengths is regarded as unreliable. Using
 								font-relative lengths in style sheets is also needed in order to reliably use relative
 								widths and heights in <a href="#media-queries">media queries</a>.</p>
-							<p>Reading devices MUST guarantee that <code>1ch</code> corresponds with the cell-to-cell
-								distance (i.e. the distance from center to center of corresponding dots in adjacent
-								cells), while <code>1em</code> should correspond with the line-to-line distance (i.e.
-								the distance from center to center of corresponding dots from one line to the next).</p>
 						</li>
 					</ul>
 
@@ -1425,7 +1421,7 @@
 				in an EPUB container, as defined in <a data-cite="epub-33#sec-container-zip">OCF ZIP Container</a>
 				[[epub-33]].</p>
 
-			<p>Packaged eBraille publications are identified by the media type identifier
+			<p>Packaged eBraille publications are also identified by the media type identifier
 					"<code>application/epub+zip</code>" [[epub-33]]. The requirements for specifying the identifier in
 				the <code>mimetype</code> file are defined in <a data-cite="epub-33#sec-zip-container-mime">OCF ZIP
 					container media type identification</a>.</p>
@@ -1433,9 +1429,9 @@
 			<p>Unlike EPUB, which does not require a file extension, a packaged eBraille file set MUST use the extension
 					<code>.ebrl</code>.</p>
 
-			<p>As eBraille does not support <a href="#">CSS font properties</a>, eBraille creators MUST NOT use EPUB's
-					<a data-cite="epub-33#sec-font-obfuscation">font obfuscation algorithm</a> [[epub-33]] to embed
-				fonts.</p>
+			<p>As the use of <a href="#css-req">CSS font properties</a> is not recommended, eBraille creators SHOULD NOT
+				use EPUB's <a data-cite="epub-33#sec-font-obfuscation">font obfuscation algorithm</a> [[epub-33]] to
+				embed fonts.</p>
 		</section>
 		<section id="ebrl-security-privacy">
 			<h2>Security and privacy</h2>
@@ -1530,72 +1526,103 @@
 			</section>
 
 			<section id="rs-req">
-				<h3>Reading system requirements</h3>
+				<h3 id="rs-req-hd">Reading system requirements</h3>
 
-				<p>An [=eBraille reading system=] MUST meet the <a data-cite="epub-rs-33#sec-rs-conformance"
-						>requirements for EPUB reading systems</a> [[epub-rs-33]], with the following differences:</p>
+				<section id="rs-req-epub" aria-labelledby="rs-req-epub-hd rs-req-hd">
+					<h4 id="rs-req-epub-hd">General</h4>
 
-				<ul>
-					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-epub-rs-conf-remote-res">remote resources</a>
-						[[epub-rs-33]].</li>
-					<li>It MUST NOT resolve [=path-absolute-URL strings=] [[url]].</li>
-					<li>As remote resources, forms, and scripting are not supported, it MUST NOT allow [=eBraille
-						publications=] to have <a data-cite="epub-rs-33#sec-epub-rs-network-access">network access</a>
-						[[epub-rs-33]]. (Note that barring network access should not prevent users from following <a
-							data-cite="epub-rs-33#sec-epub-rs-external-links">external hyperlinks</a> [[epub-rs-33]] in
-						a publication.)</li>
-					<li>It MUST only support [=eBraille content documents=] in the <code>spine</code>. The reading
-						system MAY reject eBraille publications with other formats in the spine or ignore their entries
-						when rendering the publication.</li>
-					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-xhtml-forms">form submission</a>
-						[[epub-rs-33]].</li>
-					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-scripted-content">scripting</a>
-						[[epub-rs-33]].</li>
-					<li>It is only required to support <a data-cite="epub-rs-33#sec-ocf">OCF processing</a> [[epub-33]]
-						if it supports <a href="#ebrl-packaging">packaged eBraille publications</a>.</li>
-				</ul>
+					<p>An [=eBraille reading system=] MUST meet the <a data-cite="epub-rs-33#sec-rs-conformance"
+							>requirements for EPUB reading systems</a> [[epub-rs-33]], with the following
+						differences:</p>
 
-				<p>The following EPUB reading system features [[epub-rs-33]] are not supported in the authoring of
-					eBraille publications. As these features do not affect the privacy or security of eBraille
-					publications, reading systems built on EPUB rendering engines MAY support the features although they
-					SHOULD be disabled, if possible, to discourage use by eBraille creators:</p>
+					<ul>
+						<li>It MUST NOT support <a data-cite="epub-rs-33#sec-epub-rs-conf-remote-res">remote
+								resources</a> [[epub-rs-33]].</li>
+						<li>It MUST NOT resolve [=path-absolute-URL strings=] [[url]].</li>
+						<li>As remote resources, forms, and scripting are not supported, it MUST NOT allow [=eBraille
+							publications=] to have <a data-cite="epub-rs-33#sec-epub-rs-network-access">network
+								access</a> [[epub-rs-33]]. (Note that barring network access should not prevent users
+							from following <a data-cite="epub-rs-33#sec-epub-rs-external-links">external hyperlinks</a>
+							[[epub-rs-33]] in a publication.)</li>
+						<li>It MUST only support [=eBraille content documents=] in the <code>spine</code>. The reading
+							system MAY reject eBraille publications with other formats in the spine or ignore their
+							entries when rendering the publication.</li>
+						<li>It MUST NOT support <a data-cite="epub-rs-33#sec-xhtml-forms">form submission</a>
+							[[epub-rs-33]].</li>
+						<li>It MUST NOT support <a data-cite="epub-rs-33#sec-scripted-content">scripting</a>
+							[[epub-rs-33]].</li>
+						<li>It is only required to support <a data-cite="epub-rs-33#sec-ocf">OCF processing</a>
+							[[epub-33]] if it supports <a href="#ebrl-packaging">packaged eBraille
+							publications</a>.</li>
+					</ul>
+				</section>
 
-				<ul>
-					<li><a data-cite="epub-rs-33#sec-pkg-doc-manifest">manifest fallbacks</a>.</li>
-					<li><a data-cite="epub-rs-33#sec-svg">SVG content documents</a>. (Note that this does not affect <a
-							data-cite="epub-rs-33#sec-xhtml-svg">embedded SVG</a>.)</li>
-					<li><a data-cite="epub-33#sec-css-prefixed">EPUB 3's prefixed CSS properties</a>.</li>
-					<li><a data-cite="epub-rs-33#epub-rs-33/#sec-rendering-control">fixed layouts</a>.</li>
-					<li><a data-cite="epub-rs-33#sec-container-fobfus">font obfuscation</a></li>
-					<li><a data-cite="epub-rs-33#sec-epub-rs-conf-backward">backward compatibility</a> or <a
-							data-cite="epub-rs-33#sec-epub-rs-conf-forward">forward compatibility</a> with other EPUB
-						versions.</li>
-				</ul>
+				<section id="rs-req-unsupported">
+					<h4>Unsupported features</h4>
 
-				<p>eBraille reading systems not built on EPUB rendering engines MUST NOT add support for these
-					features.</p>
+					<p>The following EPUB reading system features [[epub-rs-33]] are not supported in the authoring of
+						eBraille publications. As these features do not affect the privacy or security of eBraille
+						publications, reading systems built on EPUB rendering engines MAY support the features although
+						they SHOULD be disabled, if possible, to discourage use by eBraille creators:</p>
 
-				<p>An eBraille reading system MUST support at least one of <a href="#ebrl-packaging">packaged eBraille
-						publications</a> or <a href="#ebrl-web-deploy">web-hosted eBraille publications</a>, but SHOULD
-					support both deployment methods.</p>
+					<ul>
+						<li><a data-cite="epub-rs-33#sec-pkg-doc-manifest">manifest fallbacks</a>.</li>
+						<li><a data-cite="epub-rs-33#sec-svg">SVG content documents</a>. (Note that this does not affect
+								<a data-cite="epub-rs-33#sec-xhtml-svg">embedded SVG</a>.)</li>
+						<li><a data-cite="epub-33#sec-css-prefixed">EPUB 3's prefixed CSS properties</a>.</li>
+						<li><a data-cite="epub-rs-33#epub-rs-33/#sec-rendering-control">fixed layouts</a>.</li>
+						<li><a data-cite="epub-rs-33#sec-epub-rs-conf-backward">backward compatibility</a> or <a
+								data-cite="epub-rs-33#sec-epub-rs-conf-forward">forward compatibility</a> with other
+							EPUB versions.</li>
+					</ul>
 
-				<p>For packaged eBraille publications, reading systems:</p>
+					<p>eBraille reading systems not built on EPUB rendering engines MUST NOT add support for these
+						features.</p>
+				</section>
 
-				<ul>
-					<li>SHOULD NOT fail to open a publication solely because the <code>mimetype</code> is missing or not
-						encoded or stored as required.</li>
-					<li>are not required to <a data-cite="epub-rs-33#sec-container-iri">assign a unique URL</a>
-						[[epub-rs-33]] to publications because scripting is not supported. It is still RECOMMENDED to
-						domain isolate publications in case scripting is introduced in a future version, however.</li>
-				</ul>
+				<section>
+					<h4>Publication types</h4>
 
-				<p>In addition, eBraille reading systems MUST support PDF for tactile graphics. If an eBraille reading
-					system is not capable of rendering PDFs embedded in [=eBraille content documents=], it MUST provide
-					a mechanism that allows the user to open the graphics in an application that supports PDF
-					rendering.</p>
+					<p>An eBraille reading system MUST support at least one of <a href="#ebrl-packaging">packaged
+							eBraille publications</a> or <a href="#ebrl-web-deploy">web-hosted eBraille
+						publications</a>, but SHOULD support both deployment methods.</p>
 
-				<p>If an eBraille reading system supports web access, it SHOULD allow users to download unpackaged
-					eBraille publications hosted on the web by specifying the path to the package document.</p>
+					<p>For packaged eBraille publications, reading systems:</p>
+
+					<ul>
+						<li>SHOULD NOT fail to open a publication solely because the <code>mimetype</code> is missing or
+							not encoded or stored as required.</li>
+						<li>are not required to <a data-cite="epub-rs-33#sec-container-iri">assign a unique URL</a>
+							[[epub-rs-33]] to publications because scripting is not supported. It is still RECOMMENDED
+							to domain isolate publications in case scripting is introduced in a future version,
+							however.</li>
+					</ul>
+
+					<p>If an eBraille reading system supports web access, it SHOULD allow users to download unpackaged
+						eBraille publications hosted on the web by specifying the path to the package document.</p>
+				</section>
+
+				<section id="rs-req-fonts">
+					<h4>Font support</h4>
+
+					<p>In addition to the general requirements for CSS support in [[epub-rs-33]], Reading devices MUST
+						guarantee that <code>1ch</code> corresponds with the cell-to-cell distance (i.e., the distance
+						from center to center of corresponding dots in adjacent cells), while <code>1em</code> should
+						correspond with the line-to-line distance (i.e., the distance from center to center of
+						corresponding dots from one line to the next).</p>
+
+					<p>As the <a href="#css-req">use of CSS font properties</a> is not recommended, reading system
+						support for <a data-cite="epub-rs-33#sec-container-fobfus">font obfuscation</a> is OPTIONAL.</p>
+				</section>
+
+				<section id="rs-req-cmt">
+					<h4>Core media types</h4>
+
+					<p>eBraille reading systems MUST support PDF for tactile graphics in addition to the core media
+						types requirements in [[epub-rs-33]]. If an eBraille reading system is not capable of rendering
+						PDFs embedded in [=eBraille content documents=], it MUST provide a mechanism that allows the
+						user to open the graphics in an application that supports PDF rendering.</p>
+				</section>
 			</section>
 
 			<section id="rs-web">

--- a/index.html
+++ b/index.html
@@ -1426,8 +1426,14 @@
 				the <code>mimetype</code> file are defined in <a data-cite="epub-33#sec-zip-container-mime">OCF ZIP
 					container media type identification</a>.</p>
 
-			<p>Unlike EPUB, which does not require a file extension, a packaged eBraille file set MUST use the extension
-					<code>.ebrl</code>.</p>
+			<p>A packaged eBraille file set MUST use the extension <code>.ebrl</code>.</p>
+
+			<div class="note">
+				<p>If an eBraille file is packaged with the extension <code>.epub</code>, it will not be recognized by
+					eBraille reading system as an eBraille publication. In this case, the file would be recognized as an
+					EPUB publication and could be opened in EPUB reading systems (with some loss of braille-specific
+					functionality).</p>
+			</div>
 
 			<p>As the use of <a href="#css-req">CSS font properties</a> is not recommended, eBraille creators SHOULD NOT
 				use EPUB's <a data-cite="epub-33#sec-font-obfuscation">font obfuscation algorithm</a> [[epub-33]] to

--- a/index.html
+++ b/index.html
@@ -1421,7 +1421,21 @@
 		<section id="ebrl-packaging">
 			<h2>Packaging</h2>
 
-			<p>A packaged eBraille file set MUST use the extension <code>.ebrl</code>.</p>
+			<p>When [=eBraille publications=] are distributed to end users as a single file set, they MUST be packaged
+				in an EPUB container, as defined in <a data-cite="epub-33#sec-container-zip">OCF ZIP Container</a>
+				[[epub-33]].</p>
+
+			<p>Packaged eBraille publications are identified by the media type identifier
+					"<code>application/epub+zip</code>" [[epub-33]]. The requirements for specifying the identifier in
+				the <code>mimetype</code> file are defined in <a data-cite="epub-33#sec-zip-container-mime">OCF ZIP
+					container media type identification</a>.</p>
+
+			<p>Unlike EPUB, which does not require a file extension, a packaged eBraille file set MUST use the extension
+					<code>.ebrl</code>.</p>
+
+			<p>As eBraille does not support <a href="#">CSS font properties</a>, eBraille creators MUST NOT use EPUB's
+					<a data-cite="epub-33#sec-font-obfuscation">font obfuscation algorithm</a> [[epub-33]] to embed
+				fonts.</p>
 		</section>
 		<section id="ebrl-security-privacy">
 			<h2>Security and privacy</h2>
@@ -1530,28 +1544,49 @@
 						[[epub-rs-33]]. (Note that barring network access should not prevent users from following <a
 							data-cite="epub-rs-33#sec-epub-rs-external-links">external hyperlinks</a> [[epub-rs-33]] in
 						a publication.)</li>
-					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-pkg-doc-manifest">manifest fallbacks</a>
-						[[epub-rs-33]].</li>
 					<li>It MUST only support [=eBraille content documents=] in the <code>spine</code>. The reading
 						system MAY reject eBraille publications with other formats in the spine or ignore their entries
 						when rendering the publication.</li>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-xhtml-forms">form submission</a>
 						[[epub-rs-33]].</li>
-					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-svg">SVG content documents</a>. (Note that this
-						does not affect <a data-cite="epub-rs-33#sec-xhtml-svg">embedded SVG</a> [[epub-rs-33]].)</li>
-					<li>It MUST NOT support EPUB 3's <a data-cite="epub-33#sec-css-prefixed">prefixed CSS properties</a>
-						[[epub-33]].</li>
 					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-scripted-content">scripting</a>
 						[[epub-rs-33]].</li>
-					<li>It is not required that eBraille publications be <a data-cite="epub-rs-33#sec-container-iri"
-							>assigned a unique URL</a> [[epub-rs-33]], as scripting is not supported, but it is still
-						recommended to domain isolate publications in case scripting is introduced in a future
-						version.</li>
-					<li>It MUST NOT support <a data-cite="epub-rs-33#epub-rs-33/#sec-rendering-control">fixed
-							layouts</a> [[epub-rs-33]].</li>
-					<li>It MUST NOT support <a data-cite="epub-rs-33#sec-epub-rs-conf-backward">backward
-							compatibility</a> or <a data-cite="epub-rs-33#sec-epub-rs-conf-forward">forward
-							compatibility</a> with other EPUB versions [[epub-rs-33]].</li>
+					<li>It is only required to support <a data-cite="epub-rs-33#sec-ocf">OCF processing</a> [[epub-33]]
+						if it supports <a href="#ebrl-packaging">packaged eBraille publications</a>.</li>
+				</ul>
+
+				<p>The following EPUB reading system features [[epub-rs-33]] are not supported in the authoring of
+					eBraille publications. As these features do not affect the privacy or security of eBraille
+					publications, reading systems built on EPUB rendering engines MAY support the features although they
+					SHOULD be disabled, if possible, to discourage use by eBraille creators:</p>
+
+				<ul>
+					<li><a data-cite="epub-rs-33#sec-pkg-doc-manifest">manifest fallbacks</a>.</li>
+					<li><a data-cite="epub-rs-33#sec-svg">SVG content documents</a>. (Note that this does not affect <a
+							data-cite="epub-rs-33#sec-xhtml-svg">embedded SVG</a>.)</li>
+					<li><a data-cite="epub-33#sec-css-prefixed">EPUB 3's prefixed CSS properties</a>.</li>
+					<li><a data-cite="epub-rs-33#epub-rs-33/#sec-rendering-control">fixed layouts</a>.</li>
+					<li><a data-cite="epub-rs-33#sec-container-fobfus">font obfuscation</a></li>
+					<li><a data-cite="epub-rs-33#sec-epub-rs-conf-backward">backward compatibility</a> or <a
+							data-cite="epub-rs-33#sec-epub-rs-conf-forward">forward compatibility</a> with other EPUB
+						versions.</li>
+				</ul>
+
+				<p>eBraille reading systems not built on EPUB rendering engines MUST NOT add support for these
+					features.</p>
+
+				<p>An eBraille reading system MUST support at least one of <a href="#ebrl-packaging">packaged eBraille
+						publications</a> or <a href="#ebrl-web-deploy">web-hosted eBraille publications</a>, but SHOULD
+					support both deployment methods.</p>
+
+				<p>For packaged eBraille publications, reading systems:</p>
+
+				<ul>
+					<li>SHOULD NOT fail to open a publication solely because the <code>mimetype</code> is missing or not
+						encoded or stored as required.</li>
+					<li>are not required to <a data-cite="epub-rs-33#sec-container-iri">assign a unique URL</a>
+						[[epub-rs-33]] to publications because scripting is not supported. It is still RECOMMENDED to
+						domain isolate publications in case scripting is introduced in a future version, however.</li>
 				</ul>
 
 				<p>In addition, eBraille reading systems MUST support PDF for tactile graphics. If an eBraille reading
@@ -1563,8 +1598,8 @@
 					eBraille publications hosted on the web by specifying the path to the package document.</p>
 			</section>
 
-			<section id="rs-browser">
-				<h3>Web-hosted eBraille publications</h3>
+			<section id="rs-web">
+				<h3>Browser-based reading systems</h3>
 
 				<p>[=eBraille publications=] made available over the web in unpackaged form are expected to provide
 					minimal functionality in web browsers without the need for a dedicated [=eBraille reading

--- a/index.html
+++ b/index.html
@@ -1563,13 +1563,15 @@
 					</ul>
 				</section>
 
-				<section id="rs-req-unsupported">
-					<h4>Unsupported features</h4>
+				<section id="rs-req-non-critical">
+					<h4>Non-critical features</h4>
 
 					<p>The following EPUB reading system features [[epub-rs-33]] are not supported in the authoring of
-						eBraille publications. As these features do not affect the privacy or security of eBraille
-						publications, reading systems built on EPUB rendering engines MAY support the features although
-						they SHOULD be disabled, if possible, to discourage use by eBraille creators:</p>
+						eBraille publications. Unlike the features restricted in <a href="rs-req-epub"></a>, the
+						existence of these features will not affect the rendering of [=eBraille publications=] and does
+						not affect their privacy or security. Reading systems built on EPUB rendering engines MAY
+						support the features although they SHOULD be disabled, if possible, to discourage use by
+						eBraille creators:</p>
 
 					<ul>
 						<li><a data-cite="epub-rs-33#sec-pkg-doc-manifest">manifest fallbacks</a>.</li>


### PR DESCRIPTION
This pull request expands the packaging section to require ebraille publications be zipped in an ocf zip container when distributed. I also recommend against using the font obfuscation algorithm to embed fonts since we're recommending in the css section that epub creators not set font properties. (We could make this a must not, but then it seems like there should be a stronger ban on font-family changes.)

In trying to add the reading system requirements, I noticed that the reading system section was getting a bit big and hard to read. To try and make it more readable, I've made the following changes:

- there's now a general requirements section that covers how we diverge from epub
- there's a new unsupported features section that covers the features we're telling epub creators not to use but that aren't critical to security or privacy. As I expect ebraille reading systems will likely leverage what has already been done for epub, I don't know that there's a lot of value in forcing developers to spend time removing support that might exist. We don't want them to spend time implementing the features, but that's covered in the concluding paragraph about not adding support.
- support for packaged and unpackaged publications is covered in the publication types section
- the reading system requirements on 1ch and 1em are combined with not supporting font obfuscation in a section on fonts
- the requirement to support PDF is in a section on core media types

As always, feedback welcome on these changes.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/packaging/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/packaging/index.html)
