### PR TITLE
Updated abstract

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,8 +100,9 @@
 			<p>This specification defines eBraille, a digital reading format for braille publications.</p>
 
 			<p>The eBraille file set is based on Open Web Technologies, such as XHTML and CSS, and provides the ability
-				to encode braille in semantically enhanced markup. It is designed for both packaged distribution to end
-				users and deployment to the web for online and downloadable reading.</p>
+				to encode braille in semantically enhanced markup, allowing it to adapt to the different capabilities of
+				braille reading devices. The file set is designed for both packaged distribution to end users and
+				deployment to the web for online and downloadable reading.</p>
 		</section>
 		<section id="sotd">
 			<div data-include="common/status.html" data-include-replace="true"></div>

--- a/index.html
+++ b/index.html
@@ -99,10 +99,10 @@
 		<section id="abstract">
 			<p>This specification defines eBraille, a digital reading format for braille publications.</p>
 
-			<p>The eBraille file set is based on Open Web Technologies, such as XHTML and CSS, and provides the ability
-				to encode braille in semantically enhanced markup, allowing it to adapt to the different capabilities of
-				braille reading devices. The file set is designed for both packaged distribution to end users and
-				deployment to the web for online and downloadable reading.</p>
+			<p>eBraille uses an EPUB 3-compatible file set based on Open Web Platform &#8212; using technologies such as
+				XHTML and CSS &#8212; to encode braille in semantically enhanced markup and allow it to adapt to the
+				different capabilities of braille reading devices. The file set is designed for both packaged
+				distribution to end users and deployment to the web for online and downloadable reading.</p>
 		</section>
 		<section id="sotd">
 			<div data-include="common/status.html" data-include-replace="true"></div>

--- a/index.html
+++ b/index.html
@@ -99,9 +99,9 @@
 		<section id="abstract">
 			<p>This specification defines eBraille, a digital reading format for braille publications.</p>
 
-			<p>eBraille uses an EPUB 3-compatible file set based on Open Web Platform &#8212; using technologies such as
-				XHTML and CSS &#8212; to encode braille in semantically enhanced markup and allow it to adapt to the
-				different capabilities of braille reading devices. The file set is designed for both packaged
+			<p>eBraille uses an EPUB 3-compatible file set based on the Open Web Platform &#8212; using technologies
+				such as XHTML and CSS &#8212; to encode braille in semantically enhanced markup and allow it to adapt to
+				the different capabilities of braille reading devices. The file set is designed for both packaged
 				distribution to end users and deployment to the web for online and downloadable reading.</p>
 		</section>
 		<section id="sotd">

--- a/index.html
+++ b/index.html
@@ -98,6 +98,10 @@
 		<p class="copyright">Copyright &#169; DAISY Consortium 2023</p>
 		<section id="abstract">
 			<p>This specification defines eBraille, a digital reading format for braille publications.</p>
+
+			<p>The eBraille file set is based on Open Web Technologies, such as XHTML and CSS, and provides the ability
+				to encode braille in semantically enhanced markup. It is designed for both packaged distribution to end
+				users and deployment to the web for online and downloadable reading.</p>
 		</section>
 		<section id="sotd">
 			<div data-include="common/status.html" data-include-replace="true"></div>


### PR DESCRIPTION
I noticed that our abstract wasn't really saying anything specific about the format, as I expect it was a placeholder from when we created the document. This adds another paragraph to it so it now reads:

> This specification defines eBraille, a digital reading format for braille publications.
> 
> The eBraille file set is based on Open Web Technologies, such as XHTML and CSS, and provides the ability to encode braille in semantically enhanced markup, allowing it to adapt to the different capabilities of braille reading devices. The file set is designed for both packaged distribution to end users and deployment to the web for online and downloadable reading.

Let me know if there's anything else we should highlight in the abstract, or that doesn't need saying in the above.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/abstract/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/abstract/index.html)
