### PR TITLE
Clarify packaging files are optional when not packaging

### DIFF
--- a/index.html
+++ b/index.html
@@ -2407,7 +2407,13 @@
 				in a conforming EPUB container as defined in <a data-cite="epub-33#sec-container-zip">OCF ZIP
 					Container</a> [[epub-33]].</p>
 
-			<p>Packaged eBraille publications are use the same media type identifier as EPUB:
+			<p>As packaging is separate from the [=eBraille file set=], the <a
+					data-cite="epub-33/#sec-zip-container-mime"><code>mimetype</code></a> and <a
+					data-cite="epub-33/#sec-container-metainf-container.xml"><code>container.xml</code></a> files
+				[[epub-33]] are only required for a packaged eBraille file. The files MAY be omitted if an eBraille
+				publication is not packaged.</p>
+
+			<p>Packaged eBraille publications use the same media type identifier as EPUB:
 					<code>application/epub+zip</code> [[epub-33]]. The requirements for specifying this identifier in
 				the <code>mimetype</code> file are defined in <a data-cite="epub-33#sec-zip-container-mime">OCF ZIP
 					container media type identification</a> [[epub-33]].</p>


### PR DESCRIPTION
One last ambiguity I noticed is that packaging isn't required so it's not clear if the mimetype and container.xml files are required all the time or not.

This PR makes them optional when the file set is not packaged, since their only purposes are for identifying the container and locating the package document within it. If you don't package the file set, the required naming and location of the entry page and package document already take care of discovery, plus there's the required link to the package document in the entry page.

It probably makes life easier to have them around so it's easier to zip up the file set, and authoring tools may well always spit them out, but I don't think we need to require them if a publisher has no interest in packaging their publications.

Differences of opinion welcome, though.

* [Preview](https://raw.githack.com/daisy/ebraille/spec/container-files/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/container-files/index.html)
