### PR TITLE
Styling Best Practices: remove some editor's notes

### DIFF
--- a/best-practices/styling/index.html
+++ b/best-practices/styling/index.html
@@ -330,11 +330,11 @@
 					blank line in the same location.</p>
 
 				<aside class="example" title="Two blocked paragraphs with a blank in between">
-					<p class="ednote">
-						The “<a
-						href="../tagging/index.html#example-a-blocked-paragraph-that-is-flush-with-the-left-margin">A
-						blocked paragraph that is flush with the left margin</a>” example from
-						[[tagging]] was adapted to have two paragraphs after each other.
+					<p>
+						Two <a
+						data-cite="tagging#example-a-blocked-paragraph-that-is-flush-with-the-left-margin"
+						>“blocked” paragraphs</a> [[tagging]] (i.e. paragraphs without an
+						indentation) are separated from each other using a blank line.
 					</p>
 					<pre><code class="html">&lt;p class="blocked"&gt;⠠⠘⠥ ⠓⠑⠜⠬ ⠹ ⠓⠑ ⠁⠏⠏⠑⠜⠫ ⠎⠁⠞⠊⠎⠋⠊⠫
 ⠯ ⠒⠎⠢⠞⠫ ⠞⠕ ⠉⠕⠍⠑ ⠕⠝ ⠃⠕⠜⠙⠲ ⠠⠛⠙ ⠠⠛⠕⠙⠖ ⠠⠍⠜⠛⠜⠑⠞⠂ ⠊⠋ ⠽ ⠸⠓ ⠎⠑⠢
@@ -479,13 +479,6 @@ h2 + * {
 					mark the start of list items with a “hanging” indent.</p>
 
 				<aside class="example" title="A blocked paragraph preceding an indented one">
-					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-basic-paragraph-of-text">A
-						basic paragraph of text</a>” and “<a
-						href="../tagging/index.html#example-a-blocked-paragraph-that-is-flush-with-the-left-margin">A
-						blocked paragraph that is flush with the left margin</a>” examples from
-						[[tagging]] were combined.
-					</p>
 					<pre><code class="html">&lt;p class="blocked"&gt;⠠⠘⠥ ⠓⠑⠜⠬ ⠹ ⠓⠑ ⠁⠏⠏⠑⠜⠫ ⠎⠁⠞⠊⠎⠋⠊⠫
 ⠯ ⠒⠎⠢⠞⠫ ⠞⠕ ⠉⠕⠍⠑ ⠕⠝ ⠃⠕⠜⠙⠲ ⠠⠛⠙ ⠠⠛⠕⠙⠖ ⠠⠍⠜⠛⠜⠑⠞⠂ ⠊⠋ ⠽ ⠸⠓ ⠎⠑⠢
 ⠮ ⠍⠁⠝ ⠱⠕ ⠹⠥⠎ ⠉⠁⠏⠊⠞⠥⠇⠁⠞⠫ ⠿ ⠦ ⠎⠁⠋⠑⠞⠽⠂ ⠽⠗ ⠎⠥⠗⠏⠗⠊⠎⠑ ⠺⠙ ⠓
@@ -518,9 +511,9 @@ p.blocked {
 
 				<!--<aside class="example" title="An indented paragraph preceding a blocked one">
 					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-basic-paragraph-of-text">A
+						The “<a data-cite="tagging#example-a-basic-paragraph-of-text">A
 						basic paragraph of text</a>” and “<a
-						href="../tagging/index.html#example-a-blocked-paragraph-that-is-flush-with-the-left-margin">A
+						data-cite="tagging#example-a-blocked-paragraph-that-is-flush-with-the-left-margin">A
 						blocked paragraph that is flush with the left margin</a>” examples from
 						[[tagging]] were combined.
 					</p>
@@ -554,7 +547,7 @@ p + p.blocked {
 
 				<aside class="example" title="Two indented paragraphs with no blank in between">
 					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-basic-paragraph-of-text">A
+						The “<a data-cite="tagging#example-a-basic-paragraph-of-text">A
 						basic paragraph of text</a>” example from [[tagging] was adapted to have two
 						paragraphs after each other.
 					</p>
@@ -579,7 +572,7 @@ p + p.blocked {
 
 				<aside class="example" title="A simple list">
 					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-simple-list">A simple
+						The “<a data-cite="tagging#example-a-simple-list">A simple
 						list</a>” example from [[tagging]] was adapted to contain contracted
 						braille.
 					</p>
@@ -609,13 +602,13 @@ li {
 				</aside>-->
 
 				<aside class="example" title="A multiple-choice exercise">
-					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-multiple-choice-exercise">A
+					<!--<p class="ednote">
+						The “<a data-cite="tagging#example-a-multiple-choice-exercise">A
 						multiple-choice exercise</a>” example from [[tagging]] was adapted to
 						contain contracted braille, the <code>class="exercise"</code> was removed
 						from the inner <code>ol</code> elements, and the HTML structure was fixed
 						(<code>ol</code> should have <code>li</code> children only).
-					</p>
+					</p>-->
 					<pre><code class="html">&lt;ol class="exercise"&gt;
   &lt;li&gt;⠼⠁⠲ ⠠⠱ ⠏⠇⠁⠝⠑⠞ ⠊⠎ ⠉⠇⠕⠎⠑⠌ ⠞⠕ ⠮ ⠎⠥⠝⠦
     &lt;ol&gt;
@@ -665,7 +658,7 @@ li {
 					[[selectors]] may be used:</p>
 
 				<aside class="example" title="A multiple-choice exercise (variation)">
-					<p class="ednote">
+					<p>
 						This is a variation of
 						the <a href="#example-a-multiple-choice-exercise">multiple-choice exercise</a> example
 						with a reduced page width, to show the indentation of runovers.
@@ -794,18 +787,19 @@ h1 {
 				</p>
 
 				<aside class="example" title="Table of contents">
-					<p class="ednote">
-						Using the flexible box layout module [[css-flexbox]], tables of contents can be
-						correctly formatted, including runovers
-						and <a href="#example-table-of-contents-with-guide-dots">guide dots</a>. It however
-						comes at the price of a slightly increased complexity of the markup. Notice the
-						wrapping of items in
+					<div class="issue" data-number="140"
+					     title="Enhance “Table of contents“ example in Tagging Best Practices">
+						<p>Using the flexible box layout module, tables of contents can be correctly
+						formatted, including runovers
+						and <a href="#example-table-of-contents-with-guide-dots">guide dots</a>. It
+						however comes at the price of a slightly increased complexity of the
+						markup. Notice the wrapping of items in
 						<code>span</code> tags, and compare this with the simpler markup of the “<a
-						href="../tagging/index.html#example-a-table-of-contents-with-links">A table
+						data-cite="tagging#example-a-table-of-contents-with-links">A table
 						of contents with links</a>” example from [[tagging]]. A possible solution
 						would be to insert the <code>span</code> tags through scripting, if scripting
-						would be allowed.
-					</p>
+						would be allowed.</p>
+					</div>
 					<pre><code class="html">&lt;ol class="toc"&gt;
   &lt;li&gt;&lt;span&gt;⠠⠔⠞⠗⠕⠙⠥⠉⠰⠝&lt;/span&gt; &lt;a href="#page-5"&gt;⠼⠑&lt;/a&gt;&lt;/li&gt;
   &lt;li&gt;&lt;span&gt;⠠⠏⠗⠑⠤⠠⠋⠇⠊⠣⠞&lt;/span&gt; &lt;a href="#page-6"&gt;⠼⠋&lt;/a&gt;&lt;/li&gt;
@@ -914,15 +908,16 @@ ol.toc li span + a {
 					each row when text spans multiple rows.</p>
 
 				<aside class="example" title="Centered heading split onto multiple lines">
-					<p class="ednote">
-						BANA stipulates that centered headings should be balanced and divided at a logical
+					<div class="issue" data-number="211"
+					     title="Enhance “Multiline heading“ example in Tagging Best Practices">
+						<p>BANA stipulates that centered headings should be balanced and divided at a logical
 						location when longer than one line (rule 4.4.3). The
-						“<a href="../tagging/index.html#example-multiline-heading">Multiline heading</a>”
+						“<a data-cite="tagging#example-multiline-heading">Multiline heading</a>”
 						example in [[tagging]] suggests using <code>br</code> elements to manually divide the
 						heading into lines. However the balancing can also be achieved automatically
 						using <a data-cite="css-text-4#text-wrap-style"><code >text-wrap: balance</code></a>
-						[[css-text-4]], as this example shows.
-					</p>
+						[[css-text-4]], as this example shows.</p>
+					</div>
 					<pre><code class="html">&lt;p&gt;⠠⠮ ⠞⠑⠭⠞ ⠏⠗⠑⠉⠫⠬ ⠁ ⠉⠑⠇⠇⠤⠼⠑ ⠓⠂⠙⠬⠲&lt;/p&gt;
 &lt;h1&gt;⠠⠁ ⠉⠢⠞⠻⠫ ⠓⠂⠙⠬ ⠎⠏⠇⠊⠞ ⠕⠝ ⠍⠥⠇⠞⠊⠏⠇⠑ ⠇⠔⠑⠎ ⠾ ⠮ ⠙⠊⠧⠊⠨⠝⠎ ⠓⠁⠏⠏⠢⠬ ⠁⠞ ⠇⠕⠛⠊⠉⠁⠇ ⠏⠕⠔⠞⠎&lt;/h1&gt;
 &lt;p&gt;⠠⠮ ⠞⠑⠭⠞ ⠋⠕⠇⠇⠪⠬ ⠁ ⠉⠑⠇⠇⠤⠼⠛ ⠓⠂⠙⠬⠲&lt;/p&gt;</code></pre>
@@ -942,10 +937,10 @@ ol.toc li span + a {
 						<code>1ch</code>, the second and third lines become aligned with the grid,
 						but the first becomes misaligned.
 					</p>-->
-					<p class="ednote">
-						The actual layout does not exactly match the desired layout. The automatic
-						text balancing seems more optimal.
-					</p>
+					<div class="issue" data-number="229" title="Double check the desired layout">
+						<p>The actual layout does not exactly match the desired layout. The automatic
+						text balancing seems more optimal.</p>
+					</div>
 					<pre><code class="css" data-page-width="40">p {
    text-indent: 2ch;
 }
@@ -1012,13 +1007,9 @@ h1 {
 					surrounding text.</p>
 
 				<aside class="example" title="Simple box with blank lines">
-					<p class="ednote">
-						The “<a href="../tagging/index.html##example-a-standard">A standard box</a>”
-						example from [[tagging]] was adapted to have text before and after the box.
-					</p>
-					<p class="ednote">
-						The example contains mixed contracted and uncontracted braille.
-					</p>
+					<div class="issue" data-number="228"
+					     title="The example contains mixed contracted and uncontracted braille"
+					     ><span/></div>
 					<pre><code class="html">&lt;p&gt;⠠⠹ ⠞⠑⠭⠞ ⠏⠗⠑⠉⠫⠑⠎ ⠮ ⠃⠕⠭⠲&lt;/p&gt;
 &lt;div class="box"&gt;
    &lt;p&gt;⠠⠎⠑⠑ ⠁⠇⠎⠕ ⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠃⠑&lt;/p&gt;
@@ -1104,11 +1095,6 @@ p {
 				</aside>-->
 
 				<aside class="example" title="Simple box inside a full box with blank lines">
-					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-box-inside-another-box">A box
-						inside another box</a>” example from [[tagging]] was adapted to have text
-						before and after the outer box.
-					</p>
 					<pre><code class="html">&lt;p&gt;⠠⠹ ⠞⠑⠭⠞ ⠏⠗⠑⠉⠫⠑⠎ ⠮ ⠃⠕⠭⠲&lt;/p&gt;
 &lt;div class="box"&gt;
    &lt;div class="box"&gt;
@@ -1162,7 +1148,7 @@ p {
 				</aside>
 
 				<aside class="example" title="A box inside another box">
-					<p class="ednote">
+					<p>
 						This is another example of a box inside another box, but with a layout that
 						does not come from BANA or any other standard.
 					</p>
@@ -1262,11 +1248,6 @@ p {
 					property [[css-flexbox]] is used to align it to the right or left.</p>
 
 				<aside class="example" title="Nemeth box with blank lines">
-					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-nemeth-box">A Nemeth box</a>”
-						example from [[tagging]] was adapted to contain a multi-line formula, and
-						to have text before and after the box.
-					</p>
 					<pre><code class="html">&lt;p&gt;⠠⠹ ⠞⠑⠭⠞ ⠏⠗⠑⠉⠫⠑⠎ ⠮ ⠃⠕⠭⠲&lt;/p&gt;
 &lt;div class="box nemeth"&gt;⠼⠒⠈⠡⠢
 ⠼⠆⠈⠡⠒⠈⠡⠲
@@ -1334,11 +1315,6 @@ p {
 				</aside>
 
 				<aside class="example" title="Simple box with color">
-					<p class="ednote">
-						The “<a href="../tagging/index.html##example-a-box-with-the-color-blue">A
-						box with the color blue</a>” example from [[tagging]] was adapted to have
-						text before and after the box.
-					</p>
 					<pre><code class="html">&lt;p&gt;⠠⠹ ⠞⠑⠭⠞ ⠏⠗⠑⠉⠫⠑⠎ ⠮ ⠃⠕⠭⠲&lt;/p&gt;
 &lt;div class="box yellow"&gt;
    &lt;p&gt;⠠⠹ ⠃⠕⠭ ⠓⠁⠎ ⠁ ⠉⠕⠇⠕⠗ ⠁⠎⠎⠕⠉⠊⠁⠞⠫ ⠾ ⠭⠲&lt;/p&gt;
@@ -1401,12 +1377,6 @@ p {
 					of guide dots preceding a print page number.</p>
 
 				<aside class="example" title="Print page indicator separating two pieces of text">
-					<p class="ednote">
-						The “<a
-						href="../tagging/index.html#example-page-break-before-a-new-section-heading">Page
-						break before a new section heading</a>” example from [[tagging]] was
-						adapted to have more text before and after the print page indicator.
-					</p>
 					<pre><code class="html">&lt;p&gt;⠠⠋⠜⠑⠺⠑⠇⠇⠂ ⠍⠽ ⠙⠑⠜⠂ ⠑⠭⠉⠑⠇⠇⠢⠞ ⠠⠍⠜⠛⠜⠑⠞⠲ ⠠⠓⠂⠧⠢ ⠩⠪⠻ ⠙⠪⠝ ⠃⠨⠎⠬⠎
   ⠕⠝ ⠽⠂ ⠯ ⠎⠁⠧⠑ ⠍⠑⠂ ⠞ ⠠⠊ ⠍⠁⠽ ⠁⠛ ⠯ ⠁⠛ ⠞⠑⠌⠊⠋⠽ ⠍⠽ ⠛⠗⠁⠞⠊⠞⠥⠙⠑ ⠿
   ⠁⠇⠇ ⠽⠗ ⠇⠕⠧⠑ ⠯ ⠅⠔⠙⠰⠎⠲&lt;/p&gt;
@@ -1487,12 +1457,6 @@ h1 {
 				</aside>
 
 				<aside class="example" title="Print page number interrupting text">
-					<p class="ednote">
-						The “<a
-						href="../tagging/index.html#example-page-break-within-a-run-of-text">Page
-						break within a run of text</a>” example from [[tagging]] was adapted to
-						have more text before and after the print page indicator.
-					</p>
 					<pre><code class="html">&lt;p&gt;⠠⠘⠮ ⠗⠑⠋⠇⠑⠉⠰⠝⠎ ⠓ ⠲⠏⠑⠇⠇⠫ ⠮ ⠁⠛⠊⠞⠁⠰⠝ ⠾ ⠱ ⠠⠊ ⠆⠛⠁⠝ ⠍⠽ ⠇⠗⠂
 ⠯ ⠠⠊ ⠋⠑⠑⠇ ⠍⠽ ⠓⠑⠜⠞ ⠛⠇⠪ ⠾ ⠁⠝ ⠢⠹⠥⠎⠊⠁⠎⠍ ⠱ ⠑⠇⠑⠧⠁⠞⠑⠎ ⠍⠑ ⠞⠕
 ⠓⠂⠧⠢⠂ ⠿ ⠝⠕⠹⠬ ⠒⠞⠗⠊⠃⠥⠞⠑⠎ ⠎ ⠍⠡ ⠞⠕ ⠞⠗⠁⠝⠟⠥⠊⠇⠇⠊⠎⠑ ⠮ ⠍⠔⠙ ⠵ ⠁
@@ -1710,11 +1674,6 @@ ol.toc li span + a {
 					floated to the right side.</p>
 
 				<aside class="example" title="Line numbered prose">
-					<p class="ednote">
-						The “<a href="../tagging/index.html#example-a-paragraph-with-line-numbers">A
-						paragraph with line numbers</a>” example from [[tagging]] was adapted to have
-						more text and line numbers.
-					</p>
 					<pre><code class="html">&lt;div class="prose"&gt;
   &lt;p&gt;
     &lt;span id="line-3" class="linenum" aria-label="⠼⠉"&gt;&lt;/span&gt;
@@ -1730,11 +1689,11 @@ ol.toc li span + a {
   &lt;/p&gt;
 &lt;/div&gt;</code></pre>
 					<p>In order to obtain the following desired layout for the above HTML code,</p>
-					<p class="ednote">
-						The desired layout does not seem entirely consistent with the standard. The
+					<div class="issue" data-number="229" title="Double check the desired layout">
+						<p>The desired layout does not seem entirely consistent with the standard. The
 						word at the beginning of the third line could also fit at the end of the
-						second line.
-					</p>
+						second line.</p>
+					</div>
 					<pre><code class="formatted-braille">⠠⠽⠀⠺⠀⠗⠚⠉⠀⠞⠕⠀⠓⠑⠜⠀⠞⠀⠝⠕⠀⠲⠁⠌⠻⠀⠓⠁⠎⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠉
 ⠁⠒⠕⠍⠏⠁⠝⠊⠫⠀⠮⠀⠀⠀⠉⠕⠍⠍⠰⠑⠰⠞⠀⠷⠀⠁⠝⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠙
 ⠢⠞⠻⠏⠗⠊⠎⠑⠀⠱⠀⠽⠀⠓⠀⠗⠑⠛⠜⠙⠫⠀⠾⠀⠀⠀⠎⠡⠀⠑⠧⠊⠇⠲⠀⠀⠀⠀⠼⠑
@@ -1743,36 +1702,36 @@ ol.toc li span + a {
 ⠍⠽⠀⠺⠑⠇⠋⠜⠑⠀⠯⠀⠔⠉⠗⠂⠎⠬⠀⠒⠋⠊⠙⠰⠑⠀⠀⠀⠔⠀⠮⠀⠀⠀⠀⠀⠀⠀⠼⠛
 ⠎⠥⠒⠑⠎⠎⠀⠷⠀⠍⠽⠀⠐⠥⠞⠁⠅⠬⠲⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀</code></pre>
 					<p>the following CSS style sheet may be applied:</p>
-					<p class="ednote">
-						We make use of the non-standard CSS pseudo-class <a
+					<div class="issue" title="Non-standard pseudo-class">
+						<p>We make use of the non-standard CSS pseudo-class <a
 						href="https://developer.mozilla.org/en-US/docs/Web/CSS/:-moz-first-node"><code>:-moz-first-node</code
 						></a> in order to be able to style a <code>.linenum</code> without preceding
 						text differently (because there must not be a gap of three blank cells when
-						the first print line begins a new braille line).
-					</p>
+						the first print line begins a new braille line).</p>
+					</div>
 					<pre><code class="css" data-page-width="40">.prose {
    /* Preserve a column of four characters for the numbers. Note that, regardless
       of the width of the column, each line number is separated from the text by
-      at least two blanks. */
+      at least two blanks (due to the `margin-left: 2ch'). */
    padding-right: 4ch;
-}
-.prose .linenum:not(:-moz-first-node)::before {
-   /* The pseudo element should not take up space when at the end of the line. If
-      we use a no-break space (" \A0 "), it does take up space and as a result
-      might be moved to the next line. If we use a normal space with
-      `white-space: pre-wrap', it does not take up space, however then we can't
-      specify that the spaces at the beginning and end should be collapsible. This
-      can be fixed with scripting (see below). When scripting is disabled, we
-      choose a possible gap at the beginning of the line over a possibly too wide
-      gap. Note that we can get a dispositioned line number in either case. */
-   content: " \A0 ";
 }
 .prose .linenum::after {
    content: attr(aria-label);
    float: right;
    clear: right;
    margin-left: 2ch;
-   margin-right: -4ch;
+   margin-right: -4ch; /* move the number into the preserved column of 4ch */
+}
+/* Insert a gap of three blank cells where the line number is in the print
+   version. The pseudo element should not take up space when at the end of the
+   line. If we use a no-break space (" \A0 "), it does take up space and as a
+   result might be moved to the next line. If we use a normal space ("   ") with
+   `white-space: pre-wrap', it does not take up space, however then we can't
+   specify that the first and third (last) space should be collapsible. We choose
+   a possible gap at the beginning of the line over a possibly too wide gap. Note
+   that we can get a dispositioned line number in either case. */
+.prose .linenum:not(:-moz-first-node)::before {
+   content: " \A0 ";
 }</code></pre>
 					<details class="specification-links">
 						<summary>CSS features used in this example</summary>
@@ -1796,10 +1755,12 @@ ol.toc li span + a {
 						</ul>
 					</details>
 					<div class="ednote">
-						<p>This example shows possible use cases for allowing scripting in the
-							future. Because scripting is currenly forbidden, we obviously shouldn't
+						<p>This example shows possible use cases for allowing scripting in the future.</p>
+						<div class="issue" title="Don't include scripting in best practices">
+							<p>Because scripting is currenly forbidden, we obviously shouldn't
 							include it in the best practices. Still it seems useful to have it included
 							somewhere, to show the limitations of CSS.</p>
+						</div>
 						<details>
 							<summary>This CSS and JavaScript may be applied to enhance the styling</summary>
 							<pre><code class="css">/**
@@ -1820,6 +1781,11 @@ ol.toc li span + a {
 .prose .linenum::after {
    margin-right: calc(-1 * (var(--widest-linenum) + 2ch));
 }
+/* With scripting, we do not need to choose between a possible gap at the
+   beginning of the line and a possibly too wide gap. We insert an extra
+   "linenum-anchor" span before "linenum" spans to represent the gaps and to
+   have more control over line breaking and positioning of the gaps and
+   numbers. */
 .prose .linenum-anchor::before {
    content: " ";
 }
@@ -1897,10 +1863,11 @@ ol.toc li span + a {
 				<h3>Miscellaneous examples</h3>
 
 				<aside class="example" title="Number line">
-					<p class="ednote">
-						Missing an example in [[tagging]] of a number line. Is this to be handled
-						with a <code>pre</code> element?
-					</p>
+					<div class="issue" data-number="231"
+					     title="Missing best practices for correctly tagging this example">
+						<p>Missing an example in [[tagging]] of a “number line“. Is this to be handled
+						with a <code>pre</code> element?</p>
+					</div>
 					<pre><code class="html">&lt;pre&gt;⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠐⠒⠒⠒⠒⠒
 ⠳⠪⠐⠒⠒⠺⠒⠒⠒⠒⠺⠒⠒⠒⠒⠺⠒⠒⠒⠒⠺⠒⠳⠕
 ⠀⠀⠀⠐⠤⠼⠃⠀⠀⠀⠼⠚⠀⠀⠀⠼⠃⠀⠀⠀⠼⠙&lt;/pre&gt;</code></pre>
@@ -1924,10 +1891,11 @@ ol.toc li span + a {
 				</aside>
 
 				<aside class="example" title="Spatial math">
-					<p class="ednote">
-						Missing an example in [[tagging]] of spatial math. Is this to be handled
-						with a <code>pre</code> element?
-					</p>
+					<div class="issue" data-number="231"
+					     title="Missing best practices for correctly tagging this example">
+						<p>Missing an example in [[tagging]] of “spatial math“. Is this to be handled
+						with a <code>pre</code> element?</p>
+					</div>
 					<pre><code class="html">&lt;pre&gt;⠼⠁⠲⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠃⠲⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠉⠲
 ⠀⠀⠀⠀⠀⠀⠼⠉⠉⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠁⠚⠑⠀⠀⠀⠀⠀⠀⠀⠀⠀⠼⠓⠑
 ⠀⠀⠀⠀⠐⠖⠼⠀⠉⠀⠀⠀⠀⠀⠀⠀⠐⠖⠼⠀⠃⠉⠀⠀⠀⠀⠀⠀⠀⠐⠖⠼⠃⠚
@@ -1944,9 +1912,11 @@ ol.toc li span + a {
 				</aside>
 
 				<aside class="example" title="Centered heading with a title and subtitle on different lines">
-					<p class="ednote">
-						Missing an example in [[tagging]] of a centered heading with a title and subtitle on different lines.
-					</p>
+					<div class="issue" data-number="231"
+					     title="Missing best practices for correctly tagging this example">
+						<p>Missing an example in [[tagging]] of a centered heading with a title and
+						subtitle on different lines.</p>
+					</div>
 					<pre><code class="html">&lt;p&gt;⠠⠮ ⠞⠑⠭⠞ ⠏⠗⠑⠉⠫⠬ ⠁ ⠉⠑⠇⠇⠤⠼⠑ ⠓⠂⠙⠬⠲&lt;/p&gt;
 &lt;header&gt;
   &lt;h1&gt;⠠⠞⠊⠞⠇⠑⠒&lt;/h1&gt;


### PR DESCRIPTION
This is some cleanup of the Styling Best Practices. I've removed most of the editor's notes and added some more links to Github issues.