### PR TITLE
Auto-generate the copyright year

### DIFF
--- a/best-practices/styling/index.html
+++ b/best-practices/styling/index.html
@@ -5,6 +5,7 @@
 		<title>eBraille Styling Best Practices</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/status.js" class="remove"></script>
+		<script src="../../common/js/copyright.js" class="remove"></script>
 		<script type="text/javascript" src="replaceTaggingLinks.js"></script>
 		<script type="text/javascript" src="replaceBrfLinks.js"></script>
 		<script type="text/javascript" src="js-renderer-prototype/index.js"></script>
@@ -41,7 +42,7 @@
 				],
 				github: 'daisy/ebraille',
 				preProcess: [replaceTaggingLinks, replaceBrfLinks],
-				postProcess: [addDAISYStatus, validateExamples],
+				postProcess: [addDAISYStatus, validateExamples, addCopyrightYear],
 				localBiblio: {
 					"ebraille": {
 						href: new URL("../../", document.baseURI).href,
@@ -171,7 +172,7 @@
 		</style>
 	</head>
 	<body>
-		<p class="copyright">Copyright &#169; DAISY Consortium 2024</p>
+		<p class="copyright">Copyright &#169; DAISY Consortium <span id="copyYear">2024</span></p>
 		<section id="abstract">
 			<p>&#8230;</p>
 		</section>

--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -5,6 +5,7 @@
 		<title>eBraille Tagging Best Practices</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/status.js" class="remove"></script>
+		<script src="../../common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -43,14 +44,14 @@
 					}
 				],
 				github: 'daisy/ebraille',
-				postProcess: [addDAISYStatus]
+				postProcess: [addDAISYStatus,addCopyrightYear]
 			};
 			// ]]>
 		</script>
 		<link rel="stylesheet" href="../../common/css/common.css" />
 	</head>
 	<body>
-		<p class="copyright">Copyright &#169; DAISY Consortium 2023</p>
+		<p class="copyright">Copyright &#169; DAISY Consortium <span id="copyYear">2023</span></p>
 		<section id="abstract">
 			<p>&#8230;</p>
 		</section>

--- a/common/js/copyright.js
+++ b/common/js/copyright.js
@@ -1,0 +1,14 @@
+
+function addCopyrightYear() {
+
+	var copyrightYearSpan = document.getElementById('copyYear');
+	var copyrightYear = copyrightYearSpan.innerText;
+	var currentYear = new Date().getFullYear();
+	
+	if (Number(copyrightYear) === currentYear) {
+		return;
+	}
+	
+	copyrightYearSpan.innerText = copyrightYear + '-' + currentYear;
+
+}

--- a/index.html
+++ b/index.html
@@ -5,6 +5,7 @@
 		<title>eBraille 1.0</title>
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/js/status.js" class="remove"></script>
+		<script src="common/js/copyright.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -58,7 +59,7 @@
 					}
 				],
 				github: 'daisy/ebraille',
-				postProcess: [addDAISYStatus],
+				postProcess: [addDAISYStatus,addCopyrightYear],
 				xref: ["epub-33"],
 				localBiblio: {
 					"dpub-aria" : {
@@ -97,7 +98,7 @@
 		<link rel="stylesheet" href="common/css/common.css" />
 	</head>
 	<body>
-		<p class="copyright">Copyright &#169; DAISY Consortium 2023-2024</p>
+		<p class="copyright">Copyright &#169; DAISY Consortium <span id="copyYear">2023</span></p>
 		<section id="abstract">
 			<p>This specification defines eBraille, a digital reading format for braille publications.</p>
 


### PR DESCRIPTION
This adds a small script to handle copyright year ranges. Only the copyright start year needs to be in the span in the body. If it doesn't match the current year, the script converts it to a range from the start year to the current year.

Fixes #233


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/240.html" title="Last updated on Aug 7, 2024, 2:47 PM UTC (de1bfa8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/240/9106650...de1bfa8.html" title="Last updated on Aug 7, 2024, 2:47 PM UTC (de1bfa8)">Diff</a>