### PR TITLE
Switch infra whitespace reference to xml

### DIFF
--- a/index.html
+++ b/index.html
@@ -1721,10 +1721,9 @@
 					<ul>
 						<li><a href="https://www.unicode.org/charts/nameslist/c_2800.html">Braille Patterns</a> (U+2800
 							… U+28FF) ;</li>
-						<li>[=ASCII whitespace=] [[infra]]: <ul>
+						<li>Whitespace [[xml]]: <ul>
 								<li>TAB (U+0009)</li>
 								<li>LF (U+000A)</li>
-								<li>FF (U+000C)</li>
 								<li>CR (U+000D)</li>
 								<li>SPACE (U+0020)</li>
 							</ul>


### PR DESCRIPTION
This removes the form feed character from the list of allowable whitespace in xhtml content documents, since the inclusion of form feed isn't valid xml.

Fixes #238 

* [Preview](https://raw.githack.com/daisy/ebraille/spec/whitespace/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/whitespace/index.html)
