### PR TITLE
Remove "various strings," adds wbr and &shy; examples, and minor cleanup

### DIFF
--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -107,7 +107,7 @@
 					<dt>Reserved <code>class</code> values:</dt>
 					<dd>
 						<ul class="nomark">
-							<li><code>box</code>, <code>nemeth</code>, various strings</li>
+							<li><code>box</code>, <code>nemeth</code></li>
 						</ul>
 					</dd>
 				
@@ -302,8 +302,9 @@
 				</aside>
 
 				<aside class="example" title="Multiline heading">
-					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;br/>
-⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;br/>
+					<p>Note the use of <code>&lt;wbr/></code> instead of <code>&lt;br/></code>. <code>&lt;wbr/></code>, being optional, will only be utilized if the display being used cannot accommodate the entire heading on one line.</p>
+					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;wbr/>
+⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;wbr/>
 ⠁⠃⠕⠥⠞ ⠠⠚⠕⠓⠝ ⠠⠎⠍⠊⠞⠓&lt;/h1></code></pre>
 				</aside>
 				<aside class="example" title="Running header, also called a running head or running heading when used for the title of the work being transcribed">
@@ -321,7 +322,7 @@
 					<dt>Element(s):</dt>
 					<dd>
 						<p data-cite="html">[^img^], [^a^]</p>
-						<p>Note that <code>img</code> is used for jpg, png, and svg, while <code>a</code> is used for pdf.
+						<p>Note that <code>img</code> is used for jpg, png, and svg, while <code>a</code> is used for pdf.</p>
 					</dd>
 
 					<dt>Reserved <code>class</code> values:</dt>
@@ -527,7 +528,7 @@
 					<dt>Reserved <code>class</code> values:</dt>
 					<dd>
 						<ul class="nomark">
-							<li><code>left-aligned</code>, <code>directions</code>, <code>hanging</code><code>specific-number</code></li>
+							<li><code>left-aligned</code>, <code>directions</code>, <code>hanging</code>, <code>specific-number</code></li>
 								<ul class="nomark">
 									<li><code>left-aligned</code>&#8212; used to denote a paragraph that should be left justified.</li>
 									<li><code>directions</code>&#8212; used to denote directions that will typically accompany tests, quizzes, or multiple choice questions.</li>
@@ -579,6 +580,10 @@
 					<dt>Element(s):</dt>
 					<dd>
 						<p>[^table^], [^tr^], [^th^], [^td^], [^thead^], [^tbody^], [^tfoot^]</p>
+					</dd>
+					<dt>Attributes</dt>
+					<dd>
+						<p>[^scope^], [^headers^], [^axis^]</p>
 					</dd>
 
 					<dt>Reserved <code>class</code> values:</dt>

--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -300,11 +300,10 @@
 				<aside class="example" title="Simple heading">
 					<pre><code class="html">&lt;h1>⠠⠊⠝⠞⠗⠕⠙⠥⠉⠞⠊⠕⠝&lt;/h1></code></pre>
 				</aside>
-
 				<aside class="example" title="Multiline heading">
-					<p>Note the use of <code>&lt;wbr/></code> instead of <code>&lt;br/></code>. <code>&lt;wbr/></code>, being optional, will only be utilized if the display being used cannot accommodate the entire heading on one line.</p>
-					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;wbr/>
-⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;wbr/>
+					<p>Note that while <code>&lt;br/></code> can be used to force multiple lines, doing so will hardcode those breaks. It is better to identify the heading with either a tag or class and use CSS to center the braille &lpar;<code>text-wrap: balance</code>&rpar;. See <a href=https://daisy.github.io/ebraille/best-practices/styling/#line-breaking>Styling Best Practices, section 2.7</a>.</p>
+					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;br/>
+⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;br/>
 ⠁⠃⠕⠥⠞ ⠠⠚⠕⠓⠝ ⠠⠎⠍⠊⠞⠓&lt;/h1></code></pre>
 				</aside>
 				<aside class="example" title="Running header, also called a running head or running heading when used for the title of the work being transcribed">
@@ -661,6 +660,29 @@
   &lt;/tbody>
 &lt;/table></code></pre>
 				</aside>
+			</section>
+			<section id="Text splitting">
+				<h4>Text Splitting</h4>
+
+				<dl id="elemdef-p" class="elemdef">
+					<dt>Element(s):</dt>
+					<dd>
+						<p>[^wbr^], [^&amp;shy;^]</p>
+					</dd>
+
+					<dt>Reserved <code>class</code> values:</dt>
+					<dd>
+						<ul class="nomark">
+							<li>None.</li>
+						</ul>
+					</dd>
+				</dl>
+
+				<aside class="example" title="Text optionally broken with no hyphen">
+					<pre><code class="html">&ltp>⠼⠛⠌⠙&ltwbr>⠐⠖&ltwbr>⠼⠑⠌⠓&ltwbr>⠐⠖&ltwbr>⠼⠁⠚&ltwbr>⠐⠣⠼⠊⠊⠊&ltwbr>⠐⠤&ltwbr>⠼⠙⠐⠜&ltwbr>⠐⠣⠼⠓⠛⠉&ltwbr>⠐⠦&ltwbr>⠼⠙⠐⠜&lt/p></code></pre></aside>
+				<aside class="example" title="Text optionally broken with hyphen">
+					<p>Note that CSS can be used to set the hyphen character when <code>&amp;shy;</code> is used.</p>
+					<pre><code class="html">&ltp>⠼⠛⠌⠙&amp;shy;⠐⠖&amp;shy;⠼⠑⠌⠓&amp;shy;⠐⠖&amp;shy;⠼⠁⠚&amp;shy;⠐⠣⠼⠊⠊⠊&amp;shy;⠐⠤&amp;shy;⠼⠙⠐⠜&amp;shy;⠐⠣⠼⠓⠛⠉&amp;shy;⠐⠦&amp;shy;⠼⠙⠐⠜&lt/p></code></pre></aside>
 			</section>
 						<section id="Transcriber's Notes">
 				<h4>Transcriber's Notes</h4>

--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -301,7 +301,7 @@
 					<pre><code class="html">&lt;h1>⠠⠊⠝⠞⠗⠕⠙⠥⠉⠞⠊⠕⠝&lt;/h1></code></pre>
 				</aside>
 				<aside class="example" title="Multiline heading">
-					<p>Note that while <code>&lt;br/></code> can be used to force multiple lines, doing so will hardcode those breaks. It is better to identify the heading with either a tag or class and use CSS to center the braille &lpar;<code>text-wrap: balance</code>&rpar;. See <a href=https://daisy.github.io/ebraille/best-practices/styling/#line-breaking>Styling Best Practices, section 2.7</a>.</p>
+					<p>Note that while <code>&lt;br/></code> can be used to force multiple lines, doing so will hardcode those breaks. It is better to identify the heading with either a tag or class and use CSS to center the braille &lpar;<code>text-wrap: balance</code>&rpar;. See the <a href=https://daisy.github.io/ebraille/best-practices/styling/#line-breaking>Styling Best Practices section on line breaks</a> for more information.</p>
 					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;br/>
 ⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;br/>
 ⠁⠃⠕⠥⠞ ⠠⠚⠕⠓⠝ ⠠⠎⠍⠊⠞⠓&lt;/h1></code></pre>


### PR DESCRIPTION
Removed "various strings" from box reserved class values.

Replaced br with wbr in multiline heading example. Also added a note explaining the preference for wbr over br.

Closed a p tag. Added a comma and space where it was previously missing in the paragraph reserved class values.

Fixes #227
Fixes #224


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/253.html" title="Last updated on Aug 29, 2024, 12:53 PM UTC (d4232c1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/253/aa004f1...d4232c1.html" title="Last updated on Aug 29, 2024, 12:53 PM UTC (d4232c1)">Diff</a>