### PR TITLE
Replaced reserved class with supported role

### DIFF
--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -302,9 +302,8 @@
 				</aside>
 
 				<aside class="example" title="Multiline heading">
-					<p>Note that wbr is preferred over </p>
-					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;wbr/>
-⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;wbr/>
+					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;br/>
+⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;br/>
 ⠁⠃⠕⠥⠞ ⠠⠚⠕⠓⠝ ⠠⠎⠍⠊⠞⠓&lt;/h1></code></pre>
 				</aside>
 				<aside class="example" title="Running header, also called a running head or running heading when used for the title of the work being transcribed">

--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -302,8 +302,9 @@
 				</aside>
 
 				<aside class="example" title="Multiline heading">
-					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;br/>
-⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;br/>
+					<p>Note that wbr is preferred over </p>
+					<pre><code class="html">&lt;h1>⠠⠉⠓⠁⠏⠞⠑⠗ ⠼⠛&lt;wbr/>
+⠠⠞⠓⠑ ⠠⠗⠑⠍⠁⠗⠅⠁⠃⠇⠑ ⠠⠞⠗⠥⠞⠓&lt;wbr/>
 ⠁⠃⠕⠥⠞ ⠠⠚⠕⠓⠝ ⠠⠎⠍⠊⠞⠓&lt;/h1></code></pre>
 				</aside>
 				<aside class="example" title="Running header, also called a running head or running heading when used for the title of the work being transcribed">
@@ -492,7 +493,7 @@
 </p>
 					</dd>
 
-					<dt>Reserved <code>class</code> values:</dt>
+					<dt>Supported <code>role</code> values:</dt>
 					<dd>
 						<ul class="nomark">
 							<li><code>doc-pagebreak</code>&#8212; A separator denoting the position before which a break occurs between two contiguous pages in a statically paginated version of the content.</li>
@@ -527,7 +528,7 @@
 					<dt>Reserved <code>class</code> values:</dt>
 					<dd>
 						<ul class="nomark">
-							<li><code>left-aligned</code>, <code>directions</code>, <code>hanging</code><code>specific-number</code></li>
+							<li><code>left-aligned</code>, <code>directions</code>, <code>hanging</code>, <code>specific-number</code></li>
 								<ul class="nomark">
 									<li><code>left-aligned</code>&#8212; used to denote a paragraph that should be left justified.</li>
 									<li><code>directions</code>&#8212; used to denote directions that will typically accompany tests, quizzes, or multiple choice questions.</li>


### PR DESCRIPTION
Changes "Reserved class values" to "Supported role values" under page numbers. Was not sure if "role" still needed to be treated as code same as "class" but thinking it does.

fixes #230


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/254.html" title="Last updated on Aug 27, 2024, 5:46 PM UTC (a590773)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/254/447482f...a590773.html" title="Last updated on Aug 27, 2024, 5:46 PM UTC (a590773)">Diff</a>