### PR TITLE
Updated braille example for multiline headings

### DIFF
--- a/best-practices/styling/index.html
+++ b/best-practices/styling/index.html
@@ -924,16 +924,13 @@ ol.toc li span + a {
 					each row when text spans multiple rows.</p>
 
 				<aside class="example" title="Centered heading split onto multiple lines">
-					<div class="issue" data-number="211"
-					     title="Enhance “Multiline heading“ example in Tagging Best Practices">
-						<p>BANA stipulates that centered headings should be balanced and divided at a logical
+					<p>BANA stipulates that centered headings should be balanced and divided at a logical
 						location when longer than one line (rule 4.4.3). The
 						“<a data-cite="tagging#example-multiline-heading">Multiline heading</a>”
-						example in [[tagging]] suggests using <code>br</code> elements to manually divide the
-						heading into lines. However the balancing can also be achieved automatically
+						example in [[tagging]] explains how to use <code>br</code> elements to manually divide
+						the heading into lines. However the balancing can also be achieved automatically
 						using <a data-cite="css-text-4#text-wrap-style"><code >text-wrap: balance</code></a>
 						[[css-text-4]], as this example shows.</p>
-					</div>
 					<pre><code class="html">&lt;p&gt;⠠⠞⠓⠑ ⠞⠑⠭⠞ ⠏⠗⠑⠉⠑⠙⠊⠝⠛ ⠁ ⠉⠑⠝⠞⠑⠗⠑⠙ ⠓⠑⠁⠙⠊⠝⠛⠲&lt;/p&gt;
 &lt;h1&gt;⠠⠁ ⠉⠑⠝⠞⠑⠗⠑⠙ ⠓⠑⠁⠙⠊⠝⠛ ⠎⠏⠇⠊⠞ ⠕⠝ ⠍⠥⠇⠞⠊⠏⠇⠑ ⠇⠊⠝⠑⠎ ⠺⠊⠞⠓ ⠞⠓⠑ ⠙⠊⠧⠊⠎⠊⠕⠝⠎ ⠓⠁⠏⠏⠑⠝⠊⠝⠛ ⠁⠞ ⠇⠕⠛⠊⠉⠁⠇ ⠏⠕⠊⠝⠞⠎&lt;/h1&gt;
 &lt;p&gt;⠞⠓⠑ ⠞⠑⠭⠞ ⠋⠕⠇⠇⠕⠺⠊⠝⠛ ⠁ ⠉⠑⠝⠞⠑⠗⠑⠙ ⠓⠑⠁⠙⠊⠝⠛&lt;/p&gt;</code></pre>


### PR DESCRIPTION
Made @bertfrees changes to the multiline heading example so it properly reflects how a balanced heading would appear in braille.

Also replaced br with wbr to match the changes made in PR #253

Fixes #229

[Preview](https://raw.githack.com/daisy/ebraille/update-styling-multiline-braille-example/best-practices/styling/index.html?developer-mode=true)