### PR TITLE
Add heading role and level to examples

### DIFF
--- a/best-practices/styling/index.html
+++ b/best-practices/styling/index.html
@@ -6,6 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/status.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
+		<script src="../../common/js/examples.js" class="remove"></script>
 		<script type="text/javascript" src="replaceTaggingLinks.js"></script>
 		<script type="text/javascript" src="replaceBrfLinks.js"></script>
 		<script type="text/javascript" src="js-renderer-prototype/index.js"></script>
@@ -42,7 +43,7 @@
 				],
 				github: 'daisy/ebraille',
 				preProcess: [replaceTaggingLinks, replaceBrfLinks],
-				postProcess: [addDAISYStatus, validateExamples, addCopyrightYear],
+				postProcess: [addDAISYStatus, validateExamples, addCopyrightYear, fixExampleHeaders],
 				localBiblio: {
 					"ebraille": {
 						href: new URL("../../", document.baseURI).href,

--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -6,6 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="../../common/js/status.js" class="remove"></script>
 		<script src="../../common/js/copyright.js" class="remove"></script>
+		<script src="../../common/js/examples.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -44,7 +45,7 @@
 					}
 				],
 				github: 'daisy/ebraille',
-				postProcess: [addDAISYStatus,addCopyrightYear]
+				postProcess: [addDAISYStatus,addCopyrightYear,fixExampleHeaders]
 			};
 			// ]]>
 		</script>

--- a/common/js/examples.js
+++ b/common/js/examples.js
@@ -1,0 +1,22 @@
+
+function fixExampleHeaders() {
+
+	var examples = document.getElementsByClassName('marker');
+	
+	for (var i = 0; i < examples.length; i++) {
+		var hd = examples[i];
+		if (hd.parentElement.tagName.toLowerCase() !== 'aside') {
+			continue;
+		}
+		
+		var parent = hd.closest('section').querySelector('h1,h2,h3,h4,h5,h6');
+		var hd_num = parent.tagName.substring(1);
+		
+		if (hd_num < 6) {
+			hd_num = Number(hd_num) + 1;
+		}
+		
+		hd.setAttribute('role', 'heading');
+		hd.setAttribute('aria-level', hd_num);
+	}
+}

--- a/index.html
+++ b/index.html
@@ -811,7 +811,7 @@
 					<h4>Required metadata</h4>
 
 					<section id="dc:creator">
-						<h4>dc:creator</h4>
+						<h5>dc:creator</h5>
 
 						<p>The REQUIRED <code>dc:creator</code> element [[dcterms]] identifies the name(s) of the
 							primary author, editor, etc. Follow regional conventions for name layout.</p>
@@ -868,7 +868,7 @@
 					</section>
 
 					<section id="dc:format">
-						<h4>dc:format</h4>
+						<h5>dc:format</h5>
 
 						<p>The REQUIRED <code>dc:format</code> element [[dcterms]] identifies version of the eBraille
 							standard an publication conforms to. The [=value=] MUST contain both the name "eBraille" and
@@ -888,7 +888,7 @@
 					</section>
 
 					<section id="dc:identifier">
-						<h4>dc:identifier</h4>
+						<h5>dc:identifier</h5>
 
 						<p>The REQUIRED <code>dc:identifier</code> element [[epub-33]] contains an identifier for an
 							[=eBraille publication=], such as a UUID, DOI, or ISBN.</p>
@@ -936,7 +936,7 @@
 					</section>
 
 					<section id="dc:language">
-						<h4>dc:language</h4>
+						<h5>dc:language</h5>
 
 						<p>The REQUIRED <a href="epub-33#sec-opf-dclanguage"><code>dc:language</code> element</a>
 							[[epub-33]] identifies the language(s) of the [=eBraille publication=].</p>
@@ -982,7 +982,7 @@
 					</section>
 
 					<section id="dc:title">
-						<h4>dc:title</h4>
+						<h5>dc:title</h5>
 
 						<p>The REQUIRED <code>dc:title</code> element [[dcterms]] identifies the title of the source
 							material.</p>
@@ -1010,7 +1010,7 @@
 					</section>
 
 					<section id="dcterms:dateCopyrighted">
-						<h4>dcterms:dateCopyrighted</h4>
+						<h5>dcterms:dateCopyrighted</h5>
 
 						<p>The REQUIRED <code>dcterms:dateCopyrighted</code> property [[dcterms]] identifies the
 							copyright date of the work being transcribed.</p>
@@ -1035,7 +1035,7 @@
 					</section>
 
 					<section id="dcterms:modified">
-						<h4>dcterms:modified</h4>
+						<h5>dcterms:modified</h5>
 
 						<p>The REQUIRED <code>dcterms:modified</code> property identifies the date, in Coordinated
 							Universal Time (UTC), on which an [=eBraille publication=] was last modified.</p>
@@ -1061,7 +1061,7 @@
 					</section>
 
 					<section id="a11y:cellType">
-						<h4>a11y:cellType</h4>
+						<h5>a11y:cellType</h5>
 
 						<p>The REQUIRED <code>a11y:cellType</code> property identifies whether the text of the
 							[=eBraille publication=] is encoded using 6- or 8-dot braille characters.</p>
@@ -1091,7 +1091,7 @@
 					</section>
 
 					<section id="a11y:code">
-						<h4>a11y:code</h4>
+						<h5>a11y:code</h5>
 
 						<p>The REQUIRED <code>a11y:code</code> property identifies the name of the braille code an
 							[=eBraille publication=] has been formatted in conformance with.</p>
@@ -1132,7 +1132,7 @@
 					</section>
 
 					<section id="a11y:completeTranscription">
-						<h4>a11y:completeTranscription</h4>
+						<h5>a11y:completeTranscription</h5>
 
 						<p>The REQUIRED <code>a11y:completeTranscription</code> indicates whether the complete original
 							work has been transcribed of not.</p>
@@ -1161,7 +1161,7 @@
 					</section>
 
 					<section id="a11y:created">
-						<h4>a11y:created</h4>
+						<h5>a11y:created</h5>
 
 						<p>The <code>a11y:created</code> property identifies the date the transcription was created.</p>
 
@@ -1188,7 +1188,7 @@
 					</section>
 
 					<section id="a11y:producer">
-						<h4>a11y:producer</h4>
+						<h5>a11y:producer</h5>
 
 						<p>The <code>a11y:producer</code> property identifies the name(s) of the organization(s) or
 							individual(s) that produced the braille publication.</p>
@@ -1211,7 +1211,7 @@
 					</section>
 
 					<section id="a11y:sourcePublisher">
-						<h4>a11y:sourcePublisher</h4>
+						<h5>a11y:sourcePublisher</h5>
 
 						<p>The REQUIRED <code>a11y:sourcePublisher</code> property identifies the name of the publisher
 							of the work being transcribed.</p>
@@ -1244,7 +1244,7 @@
 					</section>
 
 					<section id="a11y:tactileGraphics">
-						<h4>a11y:tactileGraphics</h4>
+						<h5>a11y:tactileGraphics</h5>
 
 						<p>The <code>a11y:tactileGraphics</code> property identifies whether an [=eBraille publication=]
 							contains tactile graphics.</p>
@@ -1294,7 +1294,7 @@
 					<h4>Recommended metadata</h4>
 
 					<section id="dc:publisher">
-						<h4>dc:publisher</h4>
+						<h5>dc:publisher</h5>
 
 						<p>The RECOMMENDED <code>dc:publisher</code> element identifies the name(s) of the
 							organization(s) or individual(s) that published the [=eBraille publication=].</p>
@@ -1313,7 +1313,7 @@
 					</section>
 
 					<section id="dc:description">
-						<h4>dc:description</h4>
+						<h5>dc:description</h5>
 
 						<p>The RECOMMENDED <code>dc:description</code> element provides an abstract, a table of
 							contents, or a free-text account of the resource.</p>
@@ -1334,7 +1334,7 @@
 					</section>
 
 					<section id="dc:rights">
-						<h4>dc:rights</h4>
+						<h5>dc:rights</h5>
 
 						<p>The RECOMMENDED <code>dc:rights</code> element provides rights information about an
 							[=eBraille publication=]. The rights statement includes various property rights associated
@@ -1355,7 +1355,7 @@
 					</section>
 
 					<section id="dc:source">
-						<h4>dc:source</h4>
+						<h5>dc:source</h5>
 
 						<p>The RECOMMENDED <code>dc:source</code> element provides a reference to the work being
 							transcribed.</p>
@@ -1374,7 +1374,7 @@
 					</section>
 
 					<section id="dc:subject">
-						<h4>dc:subject</h4>
+						<h5>dc:subject</h5>
 
 						<p>The RECOMMENDED <code>dc:subject</code> element [[dcterms]] identifies the subject of an
 							[=eBraille publication=].</p>
@@ -1423,7 +1423,7 @@
 					</section>
 
 					<section id="dcterms:educationLevel">
-						<h4>dcterms:educationLevel</h4>
+						<h5>dcterms:educationLevel</h5>
 
 						<p>The RECOMMENDED <code>dcterms:educationLevel</code> property identifies the level of
 							education an [=eBraille publication=] is targeted to (e.g., the grade level).</p>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/js/status.js" class="remove"></script>
 		<script src="common/js/copyright.js" class="remove"></script>
+		<script src="common/js/examples.js" class="remove"></script>
 		<script class="remove">
 			//<![CDATA[
 			var respecConfig = {
@@ -59,7 +60,7 @@
 					}
 				],
 				github: 'daisy/ebraille',
-				postProcess: [addDAISYStatus,addCopyrightYear],
+				postProcess: [addDAISYStatus,addCopyrightYear,fixExampleHeaders],
 				xref: ["epub-33"],
 				localBiblio: {
 					"dpub-aria" : {


### PR DESCRIPTION
It doesn't look like we'll get a quick response from the respec group, so this will patch the example headings to add the needed aria attributes. When it's good to go, I can add it to the best practice guides before merging.

Fixes #256 

* [Preview](https://raw.githack.com/daisy/ebraille/spec/examples/index.html)

(Edit: removed the diff link as the changes are all in the attributes.)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/266.html" title="Last updated on Sep 19, 2024, 5:37 PM UTC (0cae2f1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/266/1574d98...0cae2f1.html" title="Last updated on Sep 19, 2024, 5:37 PM UTC (0cae2f1)">Diff</a>