### PR TITLE
Move braille code future work note to start of section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1093,6 +1093,11 @@
 					<section id="a11y:code">
 						<h5>a11y:code</h5>
 
+						<div class="ednote">
+							<p>A list of recommended braille code terminology will be provided with a future update to
+								this document.</p>
+						</div>
+						
 						<p>The REQUIRED <code>a11y:code</code> property identifies the name of the braille code an
 							[=eBraille publication=] has been formatted in conformance with.</p>
 
@@ -1124,11 +1129,8 @@
 &lt;/meta></pre>
 						</aside>
 
-						<div class="ednote">
-							<p>A list of recommended braille code terminology will be provided with a future update to
-								this document. For multiple braille codes, codes should be listed in descending order
-								from most to least utilized within that file.</p>
-						</div>
+						<p>For multiple braille codes, codes should be listed in descending order from most to least
+							utilized within that file.</p>
 					</section>
 
 					<section id="a11y:completeTranscription">


### PR DESCRIPTION
This is just a minor change to put the editor's note first until we get to figuring out the values for the element.