### PR TITLE
Add sourceDate property

### DIFF
--- a/index.html
+++ b/index.html
@@ -1209,7 +1209,26 @@
 
 						<p>Repeat the property for each organization or individual.</p>
 					</section>
-
+					
+					<section id="a11y:sourceDate">
+						<h5>a11y:sourceDate</h5>
+						
+						<p>The REQUIRED <code>a11y:sourceDate</code> property identifies the date on which the source
+							work was published.</p>
+						
+						<p>The property is defined in a <a href="#meta-elem"><code>meta</code> tag</a> with its
+							<code>property</code> attribute set to <code>a11y:sourceDate</code>.</p>
+						
+						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
+							expressed in W3C Date and Time Formats [[datetime]].</p>
+						
+						<aside class="example" title="Date of a source publication">
+							<pre>&lt;meta property="a11y:sourceDate">
+   2020-03-15
+&lt;/meta></pre>
+						</aside>
+					</section>
+					
 					<section id="a11y:sourcePublisher">
 						<h5>a11y:sourcePublisher</h5>
 
@@ -2706,7 +2725,7 @@
 						href="#ebrl-package-doc">package documents</a>.</p>
 			</section>
 
-			<section>
+			<section id="app-vocab-field-defs">
 				<h3>Property field definitions</h3>
 
 				<p>The fields in the vocabulary definition tables have the following implicit requirements:</p>
@@ -2794,6 +2813,70 @@
 							<th>Example:</th>
 							<td>
 								<pre>&lt;meta property="a11y:producer">APH&lt;/meta></pre>
+							</td>
+						</tr>
+					</table>
+				</section>
+				
+				<section id="sourceDate">
+					<h4>sourceDate</h4>
+					
+					<table class="tabledef">
+						<caption>Definition of the <code>sourceDate</code> property</caption>
+						<tr>
+							<th>Name:</th>
+							<td>
+								<code>sourceDate</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Description:</th>
+							<td>
+								<p>Identifies the date on which the source work was published.</p>
+							</td>
+						</tr>
+						<tr>
+							<th>Allowed value(s):</th>
+							<td>
+								<code>xsd:string</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Example:</th>
+							<td>
+								<pre>&lt;meta property="a11y:sourceDate">2010-10-10&lt;/meta></pre>
+							</td>
+						</tr>
+					</table>
+				</section>
+				
+				<section id="sourcePublisher">
+					<h4>sourcePublisher</h4>
+					
+					<table class="tabledef">
+						<caption>Definition of the <code>sourcePublisher</code> property</caption>
+						<tr>
+							<th>Name:</th>
+							<td>
+								<code>sourcePublisher</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Description:</th>
+							<td>
+								<p>Identifies the name of the publisher of the work being transcribed.</p>
+							</td>
+						</tr>
+						<tr>
+							<th>Allowed value(s):</th>
+							<td>
+								<code>xsd:string</code>
+							</td>
+						</tr>
+						<tr>
+							<th>Example:</th>
+							<td>
+								<pre>&lt;meta property="a11y:sourcePublisher">HarperCollins&lt;/meta></pre>
 							</td>
 						</tr>
 					</table>
@@ -2938,38 +3021,6 @@
 							<th>Example:</th>
 							<td>
 								<pre>&lt;meta property="a11y:minimumLines">5&lt;/meta></pre>
-							</td>
-						</tr>
-					</table>
-				</section>
-
-				<section id="sourcePublisher">
-					<h4>sourcePublisher</h4>
-
-					<table class="tabledef">
-						<caption>Definition of the <code>sourcePublisher</code> property</caption>
-						<tr>
-							<th>Name:</th>
-							<td>
-								<code>sourcePublisher</code>
-							</td>
-						</tr>
-						<tr>
-							<th>Description:</th>
-							<td>
-								<p>Identifies the name of the publisher of the work being transcribed.</p>
-							</td>
-						</tr>
-						<tr>
-							<th>Allowed value(s):</th>
-							<td>
-								<code>xsd:string</code>
-							</td>
-						</tr>
-						<tr>
-							<th>Example:</th>
-							<td>
-								<pre>&lt;meta property="a11y:sourcePublisher">HarperCollins&lt;/meta></pre>
 							</td>
 						</tr>
 					</table>
@@ -3137,6 +3188,7 @@
 						Working Draft</a></h3>
 
 				<ul>
+					<li>23-Sept-2024: Added <code>a11y:sourceDate</code> to the required metadata.</li>
 					<li>29-Aug-2024: Added media type registration for eBraille container.</li>
 					<li>08-Aug-2024: Updated the names in the <code>dc:creator</code> element examples and added
 						explanation and examples of using the <code>file-as</code> property to provide sorting info.

--- a/index.html
+++ b/index.html
@@ -1210,58 +1210,6 @@
 						<p>Repeat the property for each organization or individual.</p>
 					</section>
 					
-					<section id="a11y:sourceDate">
-						<h5>a11y:sourceDate</h5>
-						
-						<p>The REQUIRED <code>a11y:sourceDate</code> property identifies the date on which the source
-							work was published.</p>
-						
-						<p>The property is defined in a <a href="#meta-elem"><code>meta</code> tag</a> with its
-							<code>property</code> attribute set to <code>a11y:sourceDate</code>.</p>
-						
-						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
-							expressed in W3C Date and Time Formats [[datetime]].</p>
-						
-						<aside class="example" title="Date of a source publication">
-							<pre>&lt;meta property="a11y:sourceDate">
-   2020-03-15
-&lt;/meta></pre>
-						</aside>
-					</section>
-					
-					<section id="a11y:sourcePublisher">
-						<h5>a11y:sourcePublisher</h5>
-
-						<p>The REQUIRED <code>a11y:sourcePublisher</code> property identifies the name of the publisher
-							of the work being transcribed.</p>
-
-						<p>The property is defined in a <a href="#meta-elem"><code>meta</code> tag</a> with its
-								<code>property</code> attribute set to <code>a11y:sourcePublisher</code>.</p>
-
-						<aside class="example" title="A printed work with an official publisher">
-							<pre>&lt;meta property="a11y:sourcePublisher">
-   Penguin Random House
-&lt;/meta></pre>
-						</aside>
-
-						<p>If not transcribing a published print work, the name of the organization or individual that
-							produced the original text MAY be used as the publisher.</p>
-
-						<aside class="example" title="A printed work with no official publisher">
-							<pre>&lt;meta property="a11y:sourcePublisher">
-   International Council on English Braille
-&lt;/meta></pre>
-						</aside>
-
-						<p>If the work is an entirely original braille publication, use the value <code>N/A</code>.</p>
-
-						<aside class="example" title="An original braille work">
-							<pre>&lt;meta property="a11y:sourcePublisher">
-   N/A
-&lt;/meta></pre>
-						</aside>
-					</section>
-
 					<section id="a11y:tactileGraphics">
 						<h5>a11y:tactileGraphics</h5>
 
@@ -1457,6 +1405,50 @@
 						</aside>
 
 						<p>Repeat the element if the publication is intended for more than one education level.</p>
+					</section>
+				
+					<section id="a11y:sourceDate">
+						<h5>a11y:sourceDate</h5>
+						
+						<p>The REQUIRED <code>a11y:sourceDate</code> property identifies the date on which the source
+							work was published.</p>
+						
+						<p>The property is defined in a <a href="#meta-elem"><code>meta</code> tag</a> with its
+							<code>property</code> attribute set to <code>a11y:sourceDate</code>.</p>
+						
+						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
+							expressed in W3C Date and Time Formats [[datetime]].</p>
+						
+						<aside class="example" title="Date of a source publication">
+							<pre>&lt;meta property="a11y:sourceDate">
+   2020-03-15
+&lt;/meta></pre>
+						</aside>
+					</section>
+					
+					<section id="a11y:sourcePublisher">
+						<h5>a11y:sourcePublisher</h5>
+						
+						<p>The REQUIRED <code>a11y:sourcePublisher</code> property identifies the name of the publisher
+							of the work being transcribed.</p>
+						
+						<p>The property is defined in a <a href="#meta-elem"><code>meta</code> tag</a> with its
+							<code>property</code> attribute set to <code>a11y:sourcePublisher</code>.</p>
+						
+						<aside class="example" title="A printed work with an official publisher">
+							<pre>&lt;meta property="a11y:sourcePublisher">
+   Penguin Random House
+&lt;/meta></pre>
+						</aside>
+						
+						<p>If not transcribing a published print work, the name of the organization or individual that
+							produced the original text MAY be used as the publisher.</p>
+						
+						<aside class="example" title="A printed work with no official publisher">
+							<pre>&lt;meta property="a11y:sourcePublisher">
+   International Council on English Braille
+&lt;/meta></pre>
+						</aside>
 					</section>
 				</section>
 

--- a/index.html
+++ b/index.html
@@ -2724,12 +2724,13 @@
 			</section>
 		</section>
 		<section id="ebrl-meta-vocab" class="appendix">
-			<h2>Accessibility Metadata Properties</h2>
+			<h2>Accessible Formats Metadata Properties</h2>
 
 			<section id="app-vocab-about">
 				<h3>About this vocabulary</h3>
 
-				<p>This vocabulary defines metadata properties for describing [=eBraille publications=].</p>
+				<p>This vocabulary defines metadata properties for describing any accessible format, but with specific
+					focus on the needs of [=eBraille publications=].</p>
 
 				<p>Properties are only added to this vocabulary if suitable equivalents are not already defined in
 					existing vocabularies such as Dublin Core and Schema.org.</p>

--- a/index.html
+++ b/index.html
@@ -1209,7 +1209,7 @@
 
 						<p>Repeat the property for each organization or individual.</p>
 					</section>
-					
+
 					<section id="a11y:tactileGraphics">
 						<h5>a11y:tactileGraphics</h5>
 
@@ -1406,44 +1406,44 @@
 
 						<p>Repeat the element if the publication is intended for more than one education level.</p>
 					</section>
-				
+
 					<section id="a11y:sourceDate">
 						<h5>a11y:sourceDate</h5>
-						
+
 						<p>The REQUIRED <code>a11y:sourceDate</code> property identifies the date on which the source
 							work was published.</p>
-						
+
 						<p>The property is defined in a <a href="#meta-elem"><code>meta</code> tag</a> with its
-							<code>property</code> attribute set to <code>a11y:sourceDate</code>.</p>
-						
+								<code>property</code> attribute set to <code>a11y:sourceDate</code>.</p>
+
 						<p>It is RECOMMENDED that the date string conform to [[iso8601]], particularly the subset
 							expressed in W3C Date and Time Formats [[datetime]].</p>
-						
+
 						<aside class="example" title="Date of a source publication">
 							<pre>&lt;meta property="a11y:sourceDate">
    2020-03-15
 &lt;/meta></pre>
 						</aside>
 					</section>
-					
+
 					<section id="a11y:sourcePublisher">
 						<h5>a11y:sourcePublisher</h5>
-						
+
 						<p>The REQUIRED <code>a11y:sourcePublisher</code> property identifies the name of the publisher
 							of the work being transcribed.</p>
-						
+
 						<p>The property is defined in a <a href="#meta-elem"><code>meta</code> tag</a> with its
-							<code>property</code> attribute set to <code>a11y:sourcePublisher</code>.</p>
-						
+								<code>property</code> attribute set to <code>a11y:sourcePublisher</code>.</p>
+
 						<aside class="example" title="A printed work with an official publisher">
 							<pre>&lt;meta property="a11y:sourcePublisher">
    Penguin Random House
 &lt;/meta></pre>
 						</aside>
-						
+
 						<p>If not transcribing a published print work, the name of the organization or individual that
 							produced the original text MAY be used as the publisher.</p>
-						
+
 						<aside class="example" title="A printed work with no official publisher">
 							<pre>&lt;meta property="a11y:sourcePublisher">
    International Council on English Braille
@@ -2809,10 +2809,10 @@
 						</tr>
 					</table>
 				</section>
-				
+
 				<section id="sourceDate">
 					<h4>sourceDate</h4>
-					
+
 					<table class="tabledef">
 						<caption>Definition of the <code>sourceDate</code> property</caption>
 						<tr>
@@ -2841,10 +2841,10 @@
 						</tr>
 					</table>
 				</section>
-				
+
 				<section id="sourcePublisher">
 					<h4>sourcePublisher</h4>
-					
+
 					<table class="tabledef">
 						<caption>Definition of the <code>sourcePublisher</code> property</caption>
 						<tr>
@@ -3180,7 +3180,10 @@
 						Working Draft</a></h3>
 
 				<ul>
-					<li>23-Sept-2024: Added <code>a11y:sourceDate</code> to the required metadata.</li>
+					<li>26-Sept-2024: Moved <code>a11y:sourcePublisher</code> to the recommended metadata. Refer to <a
+							href="https://github.com/daisy/ebraille/issues/221">issue 221</a>.</li>
+					<li>23-Sept-2024: Added <code>a11y:sourceDate</code> to the recommended metadata. Refer to <a
+							href="https://github.com/daisy/ebraille/issues/200">issue 200</a>.</li>
 					<li>29-Aug-2024: Added media type registration for eBraille container.</li>
 					<li>08-Aug-2024: Updated the names in the <code>dc:creator</code> element examples and added
 						explanation and examples of using the <code>file-as</code> property to provide sorting info.


### PR DESCRIPTION
This pull request adds the property for expressing the date on which the source was published.

Should we also move this and sourcePublisher to the recommended properties list, as I asked in #221? Looking at the sourcePublisher definition, it says to add "N/A" if there isn't a source publisher, which is a strong case for not making it required.

Required metadata should always have a meaningful value, otherwise we keep having to propagate a workaround. It's never great to require language-specific values like "N/A", which I'll have to work into the date if we keep them required.

Fixes #221 
Fixes #200 
Fixes #168 


* [Preview](https://raw.githack.com/daisy/ebraille/spec/issue-200/index.html)
* [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/issue-200/index.html)
