### PR TITLE
Remove references to specify-number

### DIFF
--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -431,15 +431,14 @@
 						<p>The reserved class values in this section are only applied to [^ol^], [^ul^], and [^dl^].</p>
 					<dd>
 						<ul class="nomark">
-							<li><code>nomark</code>, <code>exercise</code>, <code>glossary</code>, <code>index</code>, <code>toc</code>, <code>poetry</code>, <code>specify-number</code></li>
+							<li><code>nomark</code>, <code>exercise</code>, <code>glossary</code>, <code>index</code>, <code>toc</code>, <code>poetry</code></li>
 								<ul class="nomark">
 									<li><code>nomark</code>&#8212; used to prevent the automatic inclusion of list prefixes, like bullets or numbers.</li>
 									<li><code>exercise</code>&#8212; used to denote an exercise question, typically one in a list format like a multiple-choice question.</li>
 									<li><code>glossary</code>&#8212; used to denote a glossary entry.</li>
 									<li><code>index</code>&#8212; used to denote an indices entry.</li>
 									<li><code>toc</code>&#8212; used to denote a table of contents entry.</li>
-									<li><code>poetry</code>&#8212; used to denote a line in a work of poetry that is meant to formatted in stanzas or a way that is similar to a list.</li>
-									<li><code>specify-number</code>&#8212; used to denote very specific numeric values and recommended to be used sparingly as it will hardcode those cell positions. Examples of accompanying cell positions would be <code>1-3</code>, <code>5-7</code>, etc. with the first number representing which cell the item should start in and the second number representing which cell the second line and all subsequent lines should start in.</li>
+									<li><code>poetry</code>&#8212; used to denote a line in a work of poetry that is meant to be formatted in stanzas or a way that is similar to a list.</li>
 								</ul>
 						</ul>
 					
@@ -528,12 +527,11 @@
 					<dt>Reserved <code>class</code> values:</dt>
 					<dd>
 						<ul class="nomark">
-							<li><code>left-aligned</code>, <code>directions</code>, <code>hanging</code>, <code>specific-number</code></li>
+							<li><code>left-aligned</code>, <code>directions</code>, <code>hanging</code></li>
 								<ul class="nomark">
 									<li><code>left-aligned</code>&#8212; used to denote a paragraph that should be left justified.</li>
 									<li><code>directions</code>&#8212; used to denote directions that will typically accompany tests, quizzes, or multiple choice questions.</li>
 									<li><code>hanging</code>&#8212; used to denote a paragraph in which the first line is set to the left margin, but all subsequent lines are indented.</li>
-									<li><code>specific-number</code>&#8212; used to denote very specific numeric values and recommended to be used sparingly as it will hardcode those cell positions. Examples of accompanying cell positions would be <code>1-3</code>, <code>5-7</code>, etc. with the first number representing which cell the item should start in and the second number representing which cell the second line and all subsequent lines should start in.</li>
 							</ul>
 						</ul>
 					</dd>


### PR DESCRIPTION
Removes references to specify-number from both lists and paragraphs in Tagging Best Practices. In #226 it was agreed that these class values weren't really "best practices" and more a loophole that could be utilized to make less than ideal eBraille files. If someone wants to do it, fine, but we probably shouldn't recommend it.

Fixes a typo in "poetry" description by adding the word "be."

fixes #226


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/270.html" title="Last updated on Sep 23, 2024, 5:00 PM UTC (a8d591a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/270/d1fc444...a8d591a.html" title="Last updated on Sep 23, 2024, 5:00 PM UTC (a8d591a)">Diff</a>