### PR TITLE
Replaced blocked with left-aligned in example

### DIFF
--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -543,8 +543,8 @@
 					<pre><code class="html">&lt;p>⠠⠞⠓⠑ ⠟⠥⠊⠉⠅ ⠃⠗⠕⠺⠝ ⠋⠕⠭ ⠚⠥⠍⠏⠎ ⠕⠧⠑⠗ ⠞⠓⠑ ⠇⠁⠵⠽ ⠙⠕⠛⠲&lt;/p></code></pre>
 				</aside>
 
-				<aside class="example" title="A blocked paragraph that is flush with the left margin">
-					<pre><code class="html">&lt;p class="blocked">⠠⠞⠓⠊⠎⠀⠊⠎⠀⠝⠕⠞⠀⠊⠝⠙⠑⠝⠞⠑⠙ ⠲⠲⠲&lt;/p></code></pre>
+				<aside class="example" title="A left-aligned paragraph that is flush with the left margin">
+					<pre><code class="html">&lt;p class="left-aligned">⠠⠞⠓⠊⠎⠀⠊⠎⠀⠝⠕⠞⠀⠊⠝⠙⠑⠝⠞⠑⠙ ⠲⠲⠲&lt;/p></code></pre>
 				</aside>
 			</section>
 


### PR DESCRIPTION
Leaving the example as blocked after changing the terminology to left-aligned was my mistake. Glad Bert caught it.

fixes #225


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/271.html" title="Last updated on Sep 23, 2024, 6:21 PM UTC (543f7c3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/271/d1fc444...543f7c3.html" title="Last updated on Sep 23, 2024, 6:21 PM UTC (543f7c3)">Diff</a>