### PR TITLE
Exercise example has correct markup

### DIFF
--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -458,18 +458,22 @@
 
 				<aside class="example" title="A multiple-choice exercise" id="example-a-multiple-choice-exercise">
 					<pre><code class="html">&lt;ol class="exercise">
-  &lt;li>⠼⠁⠲ ⠠⠺⠓⠊⠉⠓ ⠏⠇⠁⠝⠑⠞ ⠊⠎ ⠉⠇⠕⠑⠎⠞ ⠞⠕ ⠞⠓⠑ ⠎⠥⠝⠦&lt;/li>
-  &lt;ol class="exercise">
-    &lt;li>⠁⠲ ⠠⠧⠑⠝⠥⠎&lt;/li>
-    &lt;li>⠃⠲ ⠠⠍⠑⠗⠉⠥⠗⠽&lt;/li>
-    &lt;li>⠉⠲ ⠠⠍⠁⠗⠎&lt;/li>
-  &lt;/ol>
-  &lt;li>⠼⠃⠲ ⠠⠓⠕⠺ ⠍⠁⠝⠽ ⠍⠕⠕⠝⠎ ⠙⠕⠑⠎ ⠠⠍⠁⠗⠎ ⠓⠁⠧⠑⠦&lt;/li>
-  &lt;ol class="exercise">
-    &lt;li>⠁⠲ ⠼⠚&lt;/li>
-    &lt;li>⠃⠲ ⠼⠁&lt;/li>
-    &lt;li>⠉⠲ ⠼⠃&lt;/li>
-  &lt;/ol>
+&lt;li>⠼⠁⠲ ⠠⠺⠓⠊⠉⠓ ⠏⠇⠁⠝⠑⠞ ⠊⠎ ⠉⠇⠕⠑⠎⠞ ⠞⠕ ⠞⠓⠑ ⠎⠥⠝⠦&lt;/li>
+  &lt;li>
+      &lt;ol>
+         &lt;li>⠁⠲ ⠠⠧⠑⠝⠥⠎&lt;/li>
+    	 &lt;li>⠃⠲ ⠠⠍⠑⠗⠉⠥⠗⠽&lt;/li>
+    	 &lt;li>⠉⠲ ⠠⠍⠁⠗⠎&lt;/li>
+      &lt;/ol>
+   &lt;/li>
+&lt;li>⠼⠃⠲ ⠠⠓⠕⠺ ⠍⠁⠝⠽ ⠍⠕⠕⠝⠎ ⠙⠕⠑⠎ ⠠⠍⠁⠗⠎ ⠓⠁⠧⠑⠦&lt;/li>
+   &lt;li>
+      &lt;ol>
+         &lt;li>⠁⠲ ⠠⠧⠑⠝⠥⠎&lt;/li>
+    	 &lt;li>⠃⠲ ⠠⠍⠑⠗⠉⠥⠗⠽&lt;/li>
+    	 &lt;li>⠉⠲ ⠠⠍⠁⠗⠎&lt;/li>
+      &lt;/ol>
+   &lt;/li>
   &#8230;
 &lt;/ol></code></pre>
 				</aside>

--- a/best-practices/tagging/index.html
+++ b/best-practices/tagging/index.html
@@ -458,22 +458,20 @@
 
 				<aside class="example" title="A multiple-choice exercise" id="example-a-multiple-choice-exercise">
 					<pre><code class="html">&lt;ol class="exercise">
-&lt;li>⠼⠁⠲ ⠠⠺⠓⠊⠉⠓ ⠏⠇⠁⠝⠑⠞ ⠊⠎ ⠉⠇⠕⠑⠎⠞ ⠞⠕ ⠞⠓⠑ ⠎⠥⠝⠦&lt;/li>
-  &lt;li>
-      &lt;ol>
-         &lt;li>⠁⠲ ⠠⠧⠑⠝⠥⠎&lt;/li>
-    	 &lt;li>⠃⠲ ⠠⠍⠑⠗⠉⠥⠗⠽&lt;/li>
-    	 &lt;li>⠉⠲ ⠠⠍⠁⠗⠎&lt;/li>
-      &lt;/ol>
-   &lt;/li>
-&lt;li>⠼⠃⠲ ⠠⠓⠕⠺ ⠍⠁⠝⠽ ⠍⠕⠕⠝⠎ ⠙⠕⠑⠎ ⠠⠍⠁⠗⠎ ⠓⠁⠧⠑⠦&lt;/li>
-   &lt;li>
-      &lt;ol>
-         &lt;li>⠁⠲ ⠠⠧⠑⠝⠥⠎&lt;/li>
-    	 &lt;li>⠃⠲ ⠠⠍⠑⠗⠉⠥⠗⠽&lt;/li>
-    	 &lt;li>⠉⠲ ⠠⠍⠁⠗⠎&lt;/li>
-      &lt;/ol>
-   &lt;/li>
+&lt;li>⠼⠁⠲ ⠠⠺⠓⠊⠉⠓ ⠏⠇⠁⠝⠑⠞ ⠊⠎ ⠉⠇⠕⠑⠎⠞ ⠞⠕ ⠞⠓⠑ ⠎⠥⠝⠦
+	&lt;ol>
+		&lt;li>⠁⠲ ⠠⠧⠑⠝⠥⠎&lt;/li>
+		&lt;li>⠃⠲ ⠠⠍⠑⠗⠉⠥⠗⠽&lt;/li>
+		&lt;li>⠉⠲ ⠠⠍⠁⠗⠎&lt;/li>
+	&lt;/ol>
+&lt;/li>
+&lt;li>⠼⠃⠲ ⠠⠓⠕⠺ ⠍⠁⠝⠽ ⠍⠕⠕⠝⠎ ⠙⠕⠑⠎ ⠠⠍⠁⠗⠎ ⠓⠁⠧⠑⠦
+	&lt;ol>
+		&lt;li>⠁⠲ ⠠⠧⠑⠝⠥⠎&lt;/li>
+		&lt;li>⠃⠲ ⠠⠍⠑⠗⠉⠥⠗⠽&lt;/li>
+		&lt;li>⠉⠲ ⠠⠍⠁⠗⠎&lt;/li>
+	&lt;/ol>
+&lt;/li>
   &#8230;
 &lt;/ol></code></pre>
 				</aside>


### PR DESCRIPTION
Nest `ol` inside `li` and removed superfluous `ol class="exercise"`

fixes #210


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/pull/272.html" title="Last updated on Sep 26, 2024, 1:20 PM UTC (c1b76a8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/daisy/ebraille/272/d1fc444...c1b76a8.html" title="Last updated on Sep 26, 2024, 1:20 PM UTC (c1b76a8)">Diff</a>