### PR TITLE
Add unicode character reference for zwsp

### DIFF
--- a/index.html
+++ b/index.html
@@ -1802,8 +1802,9 @@
 					</ul>
 
 					<div class="note">
-						<p>The zero width space character is not included in this list as eBraille creators are advised
-							to use the [^wbr^] element [[html]] to indicate break opportunities within words.</p>
+						<p>The zero width space character (U+200B) is not included in this list as eBraille creators are
+							advised to use the [^wbr^] element [[html]] to indicate break opportunities within
+							words.</p>
 					</div>
 
 					<p>This restriction only applies to the renderable text of an XHTML document as well as the


### PR DESCRIPTION
Adds "(U+200B)" to the reference to zero width space in the note, just for completeness.