### PR TITLE
Remove editor notes

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,30 +74,6 @@
 						"title": "Digital Publishing WAI-ARIA Module",
 						"href": "https://www.w3.org/TR/dpub-aria/",
 						"publisher": "W3C"
-					},
-					"css-page": {
-						"aliasOf": "css-page-3"
-					},
-					"css-fonts": {
-						"aliasOf": "css-fonts-3"
-					},
-					"css-color": {
-						"aliasOf": "css-color-3"
-					},
-					"css-text-decor": {
-						"aliasOf": "css-text-decor-3"
-					},
-					"css-values": {
-						"aliasOf": "css-values-3"
-					},
-					"mediaqueries": {
-						"aliasOf": "mediaqueries-4"
-					},
-					"css-conditional": {
-						"aliasOf": "css-conditional-3"
-					},
-					"css-cascade": {
-						"aliasOf": "css-cascade-5"
 					}
 				}
 			};
@@ -424,10 +400,6 @@
      aria-label="alternative text">
    &lt;p>&lt;!-- description -->&lt;/p>
 &lt;/object></pre>
-				</aside>
-				<aside class="ednote">
-					<p>The accessibility of using an <code>object</code> element is still to be determined. Guidance on
-						how to embed PDFs may change in a future update.</p>
 				</aside>
 			</section>
 
@@ -1978,8 +1950,11 @@
 							data-cite="xml-stylesheet#"><code>xml-stylesheet</code></a> processing instructions
 						[[xml-stylesheet]].</p>
 
-					<p>[=eBraille creators=] SHOULD NOT use media queries that discriminate between a braille display
-						and a screen when the target medium is a braille display.</p>
+					<p>Media queries MUST NOT use include <a data-cite="mediaqueries#valdef-media-braille">deprecated
+								<code>braille</code> media type</a> [[mediaqueries]] to target braille displays. They
+						MUST NOT include references to <a data-cite="mediaqueries#descdef-media-grid">the
+								<code>grid</code> feature</a> [[mediaqueries]] to detect grid-based displays,
+						either.</p>
 
 					<div class="note">
 						<p>The logical consequence of this is that it will be impossible to discriminate between visual
@@ -2337,10 +2312,6 @@
 						Providing this location allows reading systems to skip the front matter and load the first page
 						when users open a publication. Other key landmarks include glossaries and indexes, as users
 						often need to access these reference sections for more information while reading.</p>
-
-					<div class="ednote">
-						<p>A future update may recommend specific landmarks to include.</p>
-					</div>
 
 					<p>The EPUB 3 specification requires that the landmarks be defined in an [[html]] [^nav^] element
 						whose <a data-cite="epub-33#dfn-epub-type"><code>epub:type</code> attribute</a> specifies the
@@ -2720,22 +2691,6 @@
 
 					<p>As the <a href="#css-req">use of CSS font properties</a> is not recommended, reading system
 						support for <a data-cite="epub-rs-33#sec-container-fobfus">font obfuscation</a> is OPTIONAL.</p>
-				</section>
-
-				<section id="rs-mq">
-					<h4>Media queries</h4>
-
-					<p>[=eBraille reading systems=] of type braille display MUST match either <code>braille</code> or
-							<code>screen</code>, and SHOULD match both. They SHOULD match both <code>(grid)</code> and
-							<code>not (grid)</code>.</p>
-
-					<div class="ednote">
-						<p>[[mediaqueries]] deprecates <a data-cite="mediaqueries#valdef-media-braille"
-									><code>braille</code></a> and requires that user agents recognize the media type as
-							valid, but make it match nothing. So maybe we should replace "<em>MUST match either
-									<code>braille</code> or <code>screen</code>, and SHOULD match both</em>" with
-								"<em>SHOULD match <code>screen</code></em>".</p>
-					</div>
 				</section>
 
 				<section id="rs-req-cmt">
@@ -3248,7 +3203,11 @@
 			<details open="">
 				<summary>Changes since the <a href="https://daisy.org/s/ebraille/1.0/WD-ebraille-20241017/">2024-10-17
 						Working Draft</a></summary>
-				<p>There have been no substantive changes since the last working draft.</p>
+				<ul>
+					<li>11-Feb-2025: Restricted authoring of the <code>braille</code> media type and <code>grid</code>
+						feature and removed the reading system requirements to handle them to resolve the open editor's
+						note.</li>
+				</ul>
 			</details>
 
 			<details>


### PR DESCRIPTION
This pull request changes the "should not" to a "must not" for authoring media queries using the braille media type. I also added an explicit restriction against using the grid feature as it was only mentioned in the following note.

As a consequence, I've removed the section on reading system handling of these values, as if they're not allowed for authoring then we shouldn't be recommending reading systems accommodate them.

But let me know if this makes sense to you, @bertfrees 

I also removed the two other editor notes about possible future directions, as these aren't necessary in the document. If there are problems with the object element or we need to say more about landmarks, we should get proper issues to address them.

And finally, I removed the aliasing of the version-less CSS modules. Respec was changed a while back to automatically match these to the latest versions.

***

[Preview](https://raw.githack.com/daisy/ebraille/fix/ed-notes/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/fix/ed-notes/index.html)
