### PR TITLE
Change recommendation that identifiers be URNs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1265,7 +1265,7 @@
 &lt;/dc:identifier>
 
 &lt;dc:identifier>
-   https://en.wikipedia.org/wiki/Braille
+   https://publisher.example.com/docs/braille/pub001
 &lt;/dc:identifier></pre>
 						</aside>
 

--- a/index.html
+++ b/index.html
@@ -1231,7 +1231,12 @@
 
 							<dt>Content model:</dt>
 							<dd>
-								<p>Text. SHOULD be formatted using a Uniform Resource Name.</p>
+								<p>Text.</p>
+								<p>[=eBraille creators=] are advised to use [=absolute-URL strings=] [[url]] for
+									identifiers whenever possible. The inclusion of a domain owned by the eBraille
+									creator can improve the uniqueness of the identifier, for example, while the use of
+									a URN with a <a data-cite="rfc8141#section-2.1">namespace identifier</a> [[rfc8141]]
+									improves processing by reading systems.</p>
 							</dd>
 
 							<dt>Attributes:</dt>
@@ -1264,13 +1269,12 @@
 &lt;/dc:identifier></pre>
 						</aside>
 
-						<p>One identifier MUST be identified as the unique identifier for the publication using the
-								<code>package</code> element's <a data-cite="epub3#attrdef-package-unique-identifier"
-									><code>unique-identifier</code> attribute</a> [[epub3]]. The
-								<code>unique-identifier</code> attribute MUST reference the <a
-								data-cite="epub/#attrdef-id"><code>id</code> attribute</a> [[epub3]] of the
-								<code>dc:identifier</code> containing the unique identifier. This identifier MUST be
-							unique to the publication.</p>
+						<p>eBraille creators have to specify one identifier as the unique identifier for the publication
+							using the <code>package</code> element's <a
+								data-cite="epub3#attrdef-package-unique-identifier"><code>unique-identifier</code>
+								attribute</a> [[epub3]]. This attribute references the <a data-cite="epub/#attrdef-id"
+									><code>id</code> attribute</a> [[epub3]] of the <code>dc:identifier</code>
+							containing the unique identifier.</p>
 
 						<aside class="example" title="Unique identifier as ISBN">
 							<pre>&lt;package &#8230; unique-identifier="uid">
@@ -3670,6 +3674,9 @@
 				<summary>Changes since the <a href="https://daisy.org/s/ebraille/1.0/CR-ebraille-20250303/">2025-03-03
 						Candidate Release</a></summary>
 				<ul>
+					<li>05-May-2025: Removed the recommendation that identifiers be URNs and replaced with the advisory
+						note from the EPUB specification about using absolute-URL strings and URNs. Refer to <a
+							href="https://github.com/daisy/ebraille/issues/320">issue 320</a>.</li>
 					<li>22-Apr-2025: Removed the <code>a11y:graphicType</code> property and updated the
 							<code>a11y:tactileGraphics</code> definition to list the formats when tactile graphics are
 						present. Refer to <a href="https://github.com/daisy/ebraille/issues/312">issue 312</a>.</li>


### PR DESCRIPTION
Per the comment in #320, this pull request replaces the recommendation that all dc:identifier values be URNs with the advisory text from the EPUB spec about on using absolute-URL strings or URNs.

Fixes #320 

* * *

[Preview](https://raw.githack.com/daisy/ebraille/spec/issue-320/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/issue-320/index.html)
