### PR TITLE
Add implementations

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,14 @@
 					happen when features are unsupported or are found to have serious security or privacy flaws.</p>
 			</section>
 
+			<section id="implementations" class="informative">
+				<h3>Implementations</h3>
+
+				<p>Refer to the <a href="https://daisy.org/s/ebraille/implementations/">eBraille Implementation
+						Report</a> for a list of validators, reading systems, and authoring tools that implement this
+					specification.</p>
+			</section>
+
 			<section id="future-dir" class="informative">
 				<h3>Future directions</h3>
 

--- a/published/implementations/index.html
+++ b/published/implementations/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-US" xml:lang="en-US">
+	<head>
+		<meta charset="utf-8" />
+		<title>eBraille Implementation Report</title>
+		<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+		<link rel="stylesheet" href="https://www.w3.org/StyleSheets/TR/2021/cg-draft" />
+		<style>
+			body {
+				background-image: none;
+				padding-left: 0 !important;
+			}
+			nav#toc {
+				display: hidden;
+			}</style>
+	</head>
+
+	<body class="h-entry informative">
+		<div class="head">
+			<hgroup>
+				<h1 id="title" class="title">eBraille Implementation Report</h1>
+			</hgroup>
+			<hr title="Separator for header" />
+		</div>
+		<section id="intro">
+			<div class="header-wrapper">
+				<h2>About this document</h2>
+			</div>
+
+			<p>This document lists known implementations of the <a href="https://daisy.org/s/ebraille/">DAISY ebraille
+					specification</a>.</p>
+
+			<p>Implementations fall into one of three categories:</p>
+
+			<ul>
+				<li><a href="#validators">Validators</a></li>
+				<li><a href="#rs">Reading systems</a></li>
+				<li><a href="#auth">Authoring tools</a></li>
+			</ul>
+
+			<p>To add an implementation to the report, please open a pull request in the <a
+					href="https://github.com/daisy/ebraille/pulls">eBraille GitHub repository</a>.</p>
+		</section>
+		<section id="implementations">
+			<div class="header-wrapper">
+				<h2>Implementations</h2>
+			</div>
+
+			<section id="validators">
+				<h3>Validators</h3>
+
+				<ul>
+					<li></li>
+				</ul>
+			</section>
+
+			<section id="rs">
+				<h3>Reading Systems</h3>
+
+				<ul>
+					<li></li>
+				</ul>
+			</section>
+
+			<section id="auth">
+				<h3>Authoring Tools</h3>
+
+				<ul>
+					<li></li>
+				</ul>
+			</section>
+		</section>
+		<p role="navigation" id="back-to-top">
+			<a href="#title"><abbr title="Back to Top">↑</abbr></a>
+		</p>
+	</body>
+</html>


### PR DESCRIPTION
This pull request adds an implementations section to the introduction as well as a stub page for listing validators, reading systems, and authoring tools that implement the specification.

Since the implementations section amounted to one sentence, it seemed to fit better before the future directions section in the intro than as its own appendix.

@wfree-aph feel free to modify the stub page however you want when you add the currently known implementations. You might want to use definition lists if you want to add a brief bit of text along with the implementation name.

***

[Preview](https://raw.githack.com/daisy/ebraille/spec/add-implementations/index.html) | [Diff](https://services.w3.org/htmldiff?doc1=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://daisy.github.io/ebraille/index.html&doc2=https://labs.w3.org/spec-generator/%3Ftype=respec%26url=https://raw.githack.com/daisy/ebraille/spec/add-implementations/index.html)

[Implementation Report Preview](https://raw.githack.com/daisy/ebraille/spec/add-implementations/published/implementations/index.html)